### PR TITLE
Don't always set Admin group on reset password

### DIFF
--- a/google_guest_agent/windows_accounts.go
+++ b/google_guest_agent/windows_accounts.go
@@ -128,9 +128,9 @@ func (k windowsKey) createOrResetPwd() (*credsJSON, error) {
 		if err := createUser(k.UserName, pwd); err != nil {
 			return nil, fmt.Errorf("error running createAdminUser: %v", err)
 		}
-	}
-	if err := addUserToGroup(k.UserName, "Administrators"); err != nil {
-		return nil, fmt.Errorf("error running addUserToGroup: %v", err)
+		if err := addUserToGroup(k.UserName, "Administrators"); err != nil {
+			return nil, fmt.Errorf("error running addUserToGroup: %v", err)
+		}
 	}
 
 	return createcredsJSON(k, pwd)


### PR DESCRIPTION
This will be added back in the future based on an option to reset password, for now we don't want to change existing behavior.