### PR TITLE
Instance and boto configs

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -190,7 +190,7 @@ func generateBotoConfig() error {
 	if err != nil {
 		return err
 	}
-	botoCfg.Section("GSUtil").Key("default_project_id").SetValue(newMetadata.Project.NumericProjectID)
+	botoCfg.Section("GSUtil").Key("default_project_id").SetValue(newMetadata.Project.NumericProjectID.String())
 	botoCfg.Section("GSUtil").Key("default_apt_version").SetValue("2")
 	botoCfg.Section("GoogleCompute").Key("service_account").SetValue("default")
 

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
-	"github.com/go-ini/ini"
 )
 
 func forwardEntryExists(fes []ipForwardEntry, fe ipForwardEntry) bool {
@@ -186,7 +185,7 @@ func generateSSHKeys() error {
 
 func generateBotoConfig() error {
 	path := "/etc/boto.cfg"
-	botoCfg, err := ini.LoadSources(ini.LoadOptions{Loose: true, Insensitive: true}, path, path+".template")
+	botoCfg, err := LooseLoad(path, path+".template")
 	if err != nil {
 		return err
 	}

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+	"github.com/go-ini/ini"
 )
 
 func forwardEntryExists(fes []ipForwardEntry, fe ipForwardEntry) bool {
@@ -44,6 +45,7 @@ func agentInit() error {
 	//  - Add route to metadata server
 	// On Linux:
 	//  - Generate SSH host keys (one time only).
+	//  - Generate boto.cfg (one time only).
 	//  - Set sysctl values.
 	//  - Set scheduler values.
 	//  - Run `google_optimize_ssd` script.
@@ -102,7 +104,10 @@ func agentInit() error {
 				if err := generateSSHKeys(); err != nil {
 					logger.Warningf("Failed to generate SSH keys: %v", err)
 				}
-				if err := ioutil.WriteFile("/etc/instance_id", []byte(newMetadata.Instance.ID.String()), 0644); err != nil {
+				if err := generateBotoConfig(); err != nil {
+					logger.Warningf("Failed to create boto.cfg: %v", err)
+				}
+				if err := ioutil.WriteFile("/etc/instance_id", []byte(newMetadata.Instance.ID), 0644); err != nil {
 					logger.Warningf("Failed to write instance ID file: %v", err)
 				}
 			}
@@ -177,6 +182,19 @@ func generateSSHKeys() error {
 		}
 	}
 	return nil
+}
+
+func generateBotoConfig() error {
+	path := "/etc/boto.cfg"
+	botoCfg, err := ini.LoadSources(ini.LoadOptions{Loose: true, Insensitive: true}, path, path+".template")
+	if err != nil {
+		return err
+	}
+	botoCfg.Section("GSUtil").Key("default_project_id").SetValue(newMetadata.Project.NumericProjectID)
+	botoCfg.Section("GSUtil").Key("default_apt_version").SetValue("2")
+	botoCfg.Section("GoogleCompute").Key("service_account").SetValue("default")
+
+	return botoCfg.SaveTo(path)
 }
 
 func writeGuestAttributes(key, value string) error {

--- a/google_guest_agent/metadata.go
+++ b/google_guest_agent/metadata.go
@@ -97,8 +97,9 @@ type networkInterfaces struct {
 }
 
 type project struct {
-	Attributes attributes
-	ProjectID  string
+	Attributes       attributes
+	ProjectID        string
+	NumericProjectID string
 }
 
 type attributes struct {
@@ -242,11 +243,12 @@ func getMetadata(ctx context.Context, hang bool) (*metadata, error) {
 	}
 	finalURL += ("&last_etag=" + etag)
 
-	req, err := http.NewRequestWithContext(ctx, "GET", finalURL, nil)
+	req, err := http.NewRequest("GET", finalURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("Metadata-Flavor", "Google")
+	req = req.WithContext(ctx)
 
 	resp, err := client.Do(req)
 	// Don't return error on a canceled context.

--- a/google_guest_agent/metadata.go
+++ b/google_guest_agent/metadata.go
@@ -99,7 +99,7 @@ type networkInterfaces struct {
 type project struct {
 	Attributes       attributes
 	ProjectID        string
-	NumericProjectID string
+	NumericProjectID json.Number
 }
 
 type attributes struct {

--- a/instance_configs.cfg
+++ b/instance_configs.cfg
@@ -1,0 +1,41 @@
+
+[Accounts]
+deprovision_remove = false
+gpasswd_add_cmd = gpasswd -a {user} {group}
+gpasswd_remove_cmd = gpasswd -d {user} {group}
+groupadd_cmd = groupadd {group}
+groups = adm,dip,docker,lxd,plugdev,video
+useradd_cmd = useradd -m -s /bin/bash -p * {user}
+userdel_cmd = userdel -r {user}
+usermod_cmd = usermod -G {groups} {user}
+
+[Daemons]
+accounts_daemon = true
+clock_skew_daemon = true
+ip_forwarding_daemon = true
+network_daemon = true
+
+[InstanceSetup]
+host_key_types = ecdsa,ed25519,rsa
+network_enabled = true
+optimize_local_ssd = true
+set_boto_config = true
+set_host_keys = true
+set_multiqueue = true
+
+[IpForwarding]
+ethernet_proto_id = 66
+ip_aliases = true
+target_instance_ips = true
+
+[MetadataScripts]
+default_shell = /bin/bash
+run_dir = 
+shutdown = true
+startup = true
+
+[NetworkInterfaces]
+dhclient_script = /sbin/google-dhclient-script
+dhcp_command = 
+ip_forwarding = true
+setup = true

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+if [ "$1" = "configure" ] ; then
+	if [ ! -f /etc/default/instance_configs.cfg ]; then 
+		cp -a "/usr/share/${DPKG_MAINTSCRIPT_PACKAGE}/instance_configs.cfg" /etc/default/
+	fi
+fi
+
+#DEBHELPER#

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+if [ "$1" = "purge" ] ; then
+	if [ -f /etc/default/instance_configs.cfg ]; then 
+		rm /etc/default/instance_configs.cfg
+	fi
+fi
+
+#DEBHELPER#

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -15,6 +15,8 @@ export GO111MODULE := on
 override_dh_auto_install:
 	# Binary-only package.
 	dh_auto_install -- --no-source
+	install -d debian/google-guest-agent/usr/share/google-guest-agent
+	install -p -m 0644 instance_configs.cfg debian/google-guest-agent/usr/share/google-guest-agent
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -42,6 +42,8 @@ GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_
 %install
 install -d %{buildroot}%{_bindir}
 install -p -m 0755 google_guest_agent/google_guest_agent %{buildroot}%{_bindir}/google_guest_agent
+install -d %{buildroot}/usr/share/google-guest-agent
+install -p -m 0644 instance_configs.cfg %{buildroot}/usr/share/google-guest-agent/instance_configs.cfg
 %if 0%{?el6}
 install -d %{buildroot}/etc/init
 install -p -m 0644 %{name}.conf %{buildroot}/etc/init
@@ -66,11 +68,21 @@ install -p -m 0644 90-%{name}.preset %{buildroot}%{_presetdir}/90-%{name}.preset
 
 %post
 %systemd_post google-guest-agent.service
+if [ $1 -eq 1 ]; then
+  if [ ! -f /etc/default/instance_configs.cfg ]; then
+    cp -a /usr/share/google-guest-agent/instance_configs.cfg /etc/default/
+  fi
+fi
 
 %preun
 %systemd_preun google-guest-agent.service
 
 %postun
 %systemd_postun google-guest-agent.service
+if [ $1 -eq 1 ]; then
+  if [ -f /etc/default/instance_configs.cfg ]; then
+    rm /etc/default/instance_configs.cfg
+  fi
+fi
 
 %endif

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -79,7 +79,8 @@ fi
 
 %postun
 %systemd_postun google-guest-agent.service
-if [ $1 -eq 1 ]; then
+if [ $1 -eq 0 ]; then
+  # Uninstall, not upgrade.
   if [ -f /etc/default/instance_configs.cfg ]; then
     rm /etc/default/instance_configs.cfg
   fi


### PR DESCRIPTION
For instance_configs.cfg:
Ship a flat text config and, if not already present in /etc/default, copy there.
Do this instead of shipping directly in the package, as that will mark it as a conffile and prompt users to confirm all changes. We intentionally give up the ability to update existing configs in order not to confuse or bother users with this new behavior. Users can now edit the main config directly, as omissions are safe (we define a default in code when we use a config).

For boto.cfg:
Would be great to do the same as instance_configs.cfg, but this file must have the numeric project ID, so it has to be generated. Do this in the one-time section i.e. "instance setup".