### PR TITLE
enable IPv6 access

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -404,8 +404,11 @@ func (a *addressMgr) set() error {
 
 // Enables or disables IPv6 on the primary interface. On agent start we may make an unnecessary dhclient call to avoid missing a necessary one.
 func configureIPv6() error {
-	ni := newMetadata.Instance.NetworkInterfaces[0]
-	oldNi := oldMetadata.Instance.NetworkInterfaces[0]
+	var ni, oldNi networkInterfaces
+	ni = newMetadata.Instance.NetworkInterfaces[0]
+	if len(oldMetadata.Instance.NetworkInterfaces) > 0 {
+		oldNi = oldMetadata.Instance.NetworkInterfaces[0]
+	}
 	iface, err := getInterfaceByMAC(ni.Mac)
 	if err != nil {
 		return err

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -97,12 +97,12 @@ func agentInit() error {
 		if err != nil && !os.IsNotExist(err) {
 			logger.Warningf("Unable to read /etc/instance_id; won't run first-boot actions")
 		} else {
-			if newMetadata.Instance.ID != string(instanceID) {
+			if newMetadata.Instance.ID.String() != string(instanceID) {
 				logger.Infof("Instance ID changed, running first-boot actions")
 				if err := generateSSHKeys(); err != nil {
 					logger.Warningf("Failed to generate SSH keys: %v", err)
 				}
-				if err := ioutil.WriteFile("/etc/instance_id", []byte(newMetadata.Instance.ID), 0644); err != nil {
+				if err := ioutil.WriteFile("/etc/instance_id", []byte(newMetadata.Instance.ID.String()), 0644); err != nil {
 					logger.Warningf("Failed to write instance ID file: %v", err)
 				}
 			}

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -180,6 +181,25 @@ func run(ctx context.Context) {
 
 	<-ctx.Done()
 	logger.Infof("GCE Agent Stopped")
+}
+
+func runCmdOutput(cmd *exec.Cmd) (string, error) {
+	output, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+	ret, err := ioutil.ReadAll(output)
+	if err != nil {
+		return "", err
+	}
+	if err := cmd.Wait(); err != nil {
+		return "", err
+	}
+
+	return string(ret), nil
 }
 
 // runCmd is exec.Cmd.Run() with a flattened error return.

--- a/google_guest_agent/metadata.go
+++ b/google_guest_agent/metadata.go
@@ -93,6 +93,7 @@ type networkInterfaces struct {
 	TargetInstanceIps []string
 	IPAliases         []string
 	Mac               string
+	DHCPv6Refresh     string
 }
 
 type project struct {

--- a/google_guest_agent/metadata.go
+++ b/google_guest_agent/metadata.go
@@ -81,7 +81,7 @@ type virtualClock struct {
 }
 
 type instance struct {
-	ID                string
+	ID                json.Number
 	MachineType       string
 	Attributes        attributes
 	NetworkInterfaces []networkInterfaces


### PR DESCRIPTION
Port the IPv6 enablement feature from `google-network-daemon` mostly as written. We don't maintain a separate list of IPv6 enabled interfaces but rather check for differences between oldMetadata and newMetadata, as with other enablements done by this agent. Add a global flag for IPv6 having been set up simply to allow the on-agent-start setup to proceed.