### PR TITLE
Script runner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleCloudPlatform/guest-agent
 go 1.12
 
 require (
+	cloud.google.com/go/storage v1.1.1
 	github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20191113181522-f7d3a48944cc
 	github.com/go-ini/ini v1.49.0
 	github.com/gopherjs/gopherjs v0.0.0-20190915194858-d3ddacdb130f // indirect

--- a/google-shutdown-scripts.conf
+++ b/google-shutdown-scripts.conf
@@ -1,0 +1,5 @@
+# Runs a shutdown script from metadata.
+start on starting rc RUNLEVEL=[06]
+task
+
+exec /usr/bin/google_metadata_script_runner shutdown

--- a/google-shutdown-scripts.service
+++ b/google-shutdown-scripts.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Google Compute Engine Shutdown Scripts
+Wants=network-online.target rsyslog.service
+After=network-online.target rsyslog.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=true
+# This service does nothing on start, and runs shutdown scripts on stop.
+ExecStop=/usr/bin/google_metadata_script_runner shutdown
+TimeoutStopSec=0
+KillMode=process
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/google-startup-scripts.conf
+++ b/google-startup-scripts.conf
@@ -1,0 +1,4 @@
+# Runs a startup script from metadata.
+start on started google-guest-agent and startup
+
+exec /usr/bin/google_metadata_script_runner startup

--- a/google-startup-scripts.service
+++ b/google-startup-scripts.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Google Compute Engine Startup Scripts
+Wants=network-online.target rsyslog.service
+After=network-online.target rsyslog.service google-guest-agent.service
+Before=apt-daily.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/google_metadata_script_runner startup
+#TimeoutStartSec is ignored for Type=oneshot service units.
+KillMode=process
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -1,0 +1,441 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// GCEMetadataScripts handles the running of metadata scripts on Google Compute
+// Engine instances.
+package main
+
+// TODO: compare log outputs in this utility to linux. incorporate config from guest-agent.
+// TODO: standardize and consolidate retries.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+)
+
+var (
+	programName    = "GCEMetadataScripts"
+	version        = "dev"
+	metadataURL    = "http://metadata.google.internal/computeMetadata/v1"
+	metadataHang   = "/?recursive=true&alt=json&timeout_sec=10&last_etag=NONE"
+	defaultTimeout = 20 * time.Second
+	powerShellArgs = []string{"-NoProfile", "-NoLogo", "-ExecutionPolicy", "Unrestricted", "-File"}
+	usageError     = fmt.Errorf("No valid arguments specified. Specify one of \"startup\", \"shutdown\" or \"specialize\"")
+
+	storageURL = "storage.googleapis.com"
+
+	bucket = `([a-z0-9][-_.a-z0-9]*)`
+	object = `(.+)`
+
+	// Many of the Google Storage URLs are supported below.
+	// It is preferred that customers specify their object using
+	// its gs://<bucket>/<object> URL.
+	bucketRegex = regexp.MustCompile(fmt.Sprintf(`^gs://%s/?$`, bucket))
+	gsRegex     = regexp.MustCompile(fmt.Sprintf(`^gs://%s/%s$`, bucket, object))
+
+	// Check for the Google Storage URLs:
+	// http://<bucket>.storage.googleapis.com/<object>
+	// https://<bucket>.storage.googleapis.com/<object>
+	gsHTTPRegex1 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://%s\.storage\.googleapis\.com/%s$`, bucket, object))
+
+	// http://storage.cloud.google.com/<bucket>/<object>
+	// https://storage.cloud.google.com/<bucket>/<object>
+	gsHTTPRegex2 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://storage\.cloud\.google\.com/%s/%s$`, bucket, object))
+
+	// Check for the other possible Google Storage URLs:
+	// http://storage.googleapis.com/<bucket>/<object>
+	// https://storage.googleapis.com/<bucket>/<object>
+	//
+	// The following are deprecated but also checked:
+	// http://commondatastorage.googleapis.com/<bucket>/<object>
+	// https://commondatastorage.googleapis.com/<bucket>/<object>
+	gsHTTPRegex3 = regexp.MustCompile(fmt.Sprintf(`^http[s]?://(?:commondata)?storage\.googleapis\.com/%s/%s$`, bucket, object))
+
+	testStorageClient *storage.Client
+)
+
+func newStorageClient(ctx context.Context) (*storage.Client, error) {
+	if testStorageClient != nil {
+		return testStorageClient, nil
+	}
+	return storage.NewClient(ctx)
+}
+
+func downloadGSURL(ctx context.Context, bucket, object string, file *os.File) error {
+	client, err := newStorageClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create storage client: %v", err)
+	}
+	defer client.Close()
+
+	r, err := client.Bucket(bucket).Object(object).NewReader(ctx)
+	if err != nil {
+		return fmt.Errorf("error reading object %q: %v", object, err)
+	}
+	defer r.Close()
+
+	_, err = io.Copy(file, r)
+	return err
+}
+
+func downloadURL(url string, file *os.File) error {
+	// Retry up to 3 times, only wait 1 second between retries.
+	var res *http.Response
+	var err error
+	for i := 1; ; i++ {
+		res, err = http.Get(url)
+		if err != nil && i > 3 {
+			return err
+		}
+		if err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %q, bad status: %s", url, res.Status)
+	}
+
+	_, err = io.Copy(file, res.Body)
+	return err
+}
+
+func downloadScript(ctx context.Context, path string, file *os.File) error {
+	// Startup scripts may run before DNS is running on some systems,
+	// particularly once a system is promoted to a domain controller.
+	// Try to lookup storage.googleapis.com and sleep for up to 100s if
+	// we get an error.
+	// TODO: do we need to do this on every script?
+	for i := 0; i < 20; i++ {
+		if _, err := net.LookupHost(storageURL); err == nil {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+	bucket, object := parseGCS(path)
+	if bucket != "" && object != "" {
+		// TODO: why is this retry outer, but downloadURL retry is inner?
+		// Retry up to 3 times, only wait 1 second between retries.
+		for i := 1; ; i++ {
+			err := downloadGSURL(ctx, bucket, object, file)
+			if err == nil {
+				return nil
+			}
+			if err != nil && i > 3 {
+				logger.Infof("Failed to download GCS path: %v", err)
+				break
+			}
+			time.Sleep(1 * time.Second)
+		}
+		logger.Infof("Trying unauthenticated download")
+		path = fmt.Sprintf("https://%s/%s/%s", storageURL, bucket, object)
+	}
+
+	// Fall back to an HTTP GET of the URL.
+	return downloadURL(path, file)
+}
+
+func parseGCS(path string) (string, string) {
+	for _, re := range []*regexp.Regexp{gsRegex, gsHTTPRegex1, gsHTTPRegex2, gsHTTPRegex3} {
+		match := re.FindStringSubmatch(path)
+		if len(match) == 3 {
+			return match[1], match[2]
+		}
+	}
+	return "", ""
+}
+
+func getMetadataKey(key string) (string, error) {
+	md, err := getMetadata(key, false)
+	if err != nil {
+		return "", err
+	}
+	return string(md), nil
+}
+
+func getMetadataAttributes(key string) (map[string]string, error) {
+	md, err := getMetadata(key, true)
+	if err != nil {
+		return nil, err
+	}
+	var att map[string]string
+	return att, json.Unmarshal(md, &att)
+}
+
+func getMetadata(key string, recurse bool) ([]byte, error) {
+	client := &http.Client{
+		Timeout: defaultTimeout,
+	}
+
+	url := metadataURL + key
+	if recurse {
+		url += metadataHang
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Metadata-Flavor", "Google")
+
+	var res *http.Response
+	// Retry forever, increase sleep between retries (up to 5 times) in order
+	// to wait for slow network initialization.
+	var rt time.Duration
+	for i := 1; ; i++ {
+		res, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		if i < 6 {
+			rt = time.Duration(3*i) * time.Second
+		}
+		logger.Errorf("error connecting to metadata server, retrying in %s, error: %v", rt, err)
+		time.Sleep(rt)
+	}
+	defer res.Body.Close()
+
+	md, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return md, nil
+}
+
+// runScript makes a temporary directory and temporary file for the script, downloads and then runs it.
+func runScript(ctx context.Context, key, value string) error {
+	var u *url.URL
+	if strings.HasSuffix(key, "-url") {
+		var err error
+		u, err = url.Parse(strings.TrimSpace(value))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Make temp directory.
+	// dir, err := ioutil.TempDir(config.Section("MetadataScripts").Key("run_dir"), "metadata-scripts")
+	dir, err := ioutil.TempDir("", "metadata-scripts")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	// These extensions need to be present on Windows. Doesn't hurt to add
+	// on other systems though.
+	tmpFile := filepath.Join(dir, key)
+	for _, ext := range []string{"bat", "cmd", "ps1"} {
+		switch {
+		case strings.HasSuffix(key, fmt.Sprintf("-%s", ext)),
+			u != nil && strings.HasSuffix(u.Path, fmt.Sprintf(".%s", ext)):
+			tmpFile = fmt.Sprintf("%s.%s", tmpFile, ext)
+			break
+		}
+	}
+
+	// Create or download files.
+	if u != nil {
+		file, err := os.OpenFile(tmpFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+		if err != nil {
+			return fmt.Errorf("error opening temp file: %v", err)
+		}
+		if err := downloadScript(ctx, value, file); err != nil {
+			file.Close()
+			return err
+		}
+		file.Close()
+	} else {
+		if err := ioutil.WriteFile(tmpFile, []byte(value), 0755); err != nil {
+			return err
+		}
+	}
+
+	// Craft the command to run.
+	var c *exec.Cmd
+	if strings.HasSuffix(tmpFile, ".ps1") {
+		c = exec.Command("powershell.exe", append(powerShellArgs, tmpFile)...)
+	} else {
+		if runtime.GOOS == "windows" {
+			c = exec.Command(tmpFile)
+		} else {
+			//c = exec.Command(config.Section("MetadataScripts").Key("default_shell").MustString("/bin/bash"), "-c", tmpFile)
+			c = exec.Command("/bin/bash", "-c", tmpFile)
+		}
+	}
+
+	return runCmd(c, key)
+}
+
+func runCmd(c *exec.Cmd, name string) error {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer pr.Close()
+
+	c.Stdout = pw
+	c.Stderr = pw
+
+	if err := c.Start(); err != nil {
+		return err
+	}
+	pw.Close()
+
+	in := bufio.NewScanner(pr)
+	for in.Scan() {
+		logger.Log(logger.LogEntry{
+			Message:   fmt.Sprintf("%s: %s", name, in.Text()),
+			CallDepth: 3,
+			Severity:  logger.Info,
+		})
+	}
+
+	return c.Wait()
+}
+
+// getWantedKeys returns the list of keys to check for a given type of script and OS.
+func getWantedKeys(args []string, os string) ([]string, error) {
+	if len(args) != 2 {
+		return nil, usageError
+	}
+	prefix := args[1]
+	switch prefix {
+	case "specialize":
+		prefix = "sysprep-specialize"
+	case "startup", "shutdown":
+		if os == "windows" {
+			prefix = "windows-" + prefix
+		}
+		// if !config.Section("MetadataScripts").Key(prefix).MustBool(true) {
+		// 	return nil, fmt.Errorf("%s scripts disabled in instance config.", prefix)
+		// }
+	default:
+		return nil, usageError
+	}
+
+	var mdkeys []string
+	suffixes := []string{"url"}
+	if os == "windows" {
+		// This ordering matters. URL is last on Windows, first otherwise.
+		suffixes = []string{"ps1", "cmd", "bat", "url"}
+	}
+
+	for _, suffix := range suffixes {
+		mdkeys = append(mdkeys, fmt.Sprintf("%s-script-%s", prefix, suffix))
+	}
+
+	// The 'bare' startup-script or shutdown-script key, not supported on Windows.
+	if os != "windows" {
+		mdkeys = append(mdkeys, fmt.Sprintf("%s-script", prefix))
+	}
+
+	return mdkeys, nil
+}
+
+func parseMetadata(md map[string]string, wanted []string) map[string]string {
+	found := make(map[string]string)
+	for _, key := range wanted {
+		val, ok := md[key]
+		if !ok || val == "" {
+			continue
+		}
+		found[key] = val
+	}
+	return found
+}
+
+// getExistingKeys returns the wanted keys that are set in metadata.
+func getExistingKeys(wanted []string) (map[string]string, error) {
+	for _, attrs := range []string{"/instance/attributes", "/project/attributes"} {
+		md, err := getMetadataAttributes(attrs)
+		if err != nil {
+			return nil, err
+		}
+		if found := parseMetadata(md, wanted); len(found) != 0 {
+			return found, nil
+		}
+	}
+	return nil, nil
+}
+
+func logFormat(e logger.LogEntry) string {
+	now := time.Now().Format("2006/01/02 15:04:05")
+	return fmt.Sprintf("%s %s: %s", now, programName, e.Message)
+}
+
+func main() {
+	ctx := context.Background()
+	opts := logger.LogOpts{
+		LoggerName:     programName,
+		FormatFunction: logFormat,
+		Writers:        []io.Writer{os.Stdout},
+	}
+
+	// The keys to check vary based on the argument and the OS. Also functions to validate arguments.
+	wantedKeys, err := getWantedKeys(os.Args, runtime.GOOS)
+	if err != nil {
+		fmt.Printf("%s\n", err.Error())
+		os.Exit(2)
+	}
+
+	projectID, err := getMetadataKey("/project/project-id")
+	if err == nil {
+		opts.ProjectName = projectID
+	} else {
+		// TODO: just consider it disabled if no project is set..
+		opts.DisableCloudLogging = true
+	}
+	logger.Init(ctx, opts)
+
+	logger.Infof("Starting %s scripts (version %s).", os.Args[1], version)
+
+	scripts, err := getExistingKeys(wantedKeys)
+	if err != nil {
+		logger.Fatalf(err.Error())
+	}
+
+	if len(scripts) == 0 {
+		logger.Infof("No %s scripts to run.", os.Args[1])
+		return
+	}
+
+	for key, value := range scripts {
+		logger.Infof("Found %s in metadata.", key)
+		if err := runScript(ctx, key, value); err != nil {
+			logger.Infof("%s %s", key, err)
+			continue
+		}
+		logger.Infof("%s exit status 0", key)
+	}
+
+	logger.Infof("Finished running %s scripts.", os.Args[1])
+}

--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -49,7 +49,7 @@ var (
 	metadataHang   = "/?recursive=true&alt=json&timeout_sec=10&last_etag=NONE"
 	defaultTimeout = 20 * time.Second
 	powerShellArgs = []string{"-NoProfile", "-NoLogo", "-ExecutionPolicy", "Unrestricted", "-File"}
-	usageError     = fmt.Errorf("No valid arguments specified. Specify one of \"startup\", \"shutdown\" or \"specialize\"")
+	errUsage       = fmt.Errorf("No valid arguments specified. Specify one of \"startup\", \"shutdown\" or \"specialize\"")
 	config         *ini.File
 
 	storageURL = "storage.googleapis.com"
@@ -330,7 +330,7 @@ func runCmd(c *exec.Cmd, name string) error {
 // getWantedKeys returns the list of keys to check for a given type of script and OS.
 func getWantedKeys(args []string, os string) ([]string, error) {
 	if len(args) != 2 {
-		return nil, usageError
+		return nil, errUsage
 	}
 	prefix := args[1]
 	switch prefix {
@@ -341,10 +341,10 @@ func getWantedKeys(args []string, os string) ([]string, error) {
 			prefix = "windows-" + prefix
 		}
 		if !config.Section("MetadataScripts").Key(prefix).MustBool(true) {
-			return nil, fmt.Errorf("%s scripts disabled in instance config.", prefix)
+			return nil, fmt.Errorf("%s scripts disabled in instance config", prefix)
 		}
 	default:
-		return nil, usageError
+		return nil, errUsage
 	}
 
 	var mdkeys []string

--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -414,6 +414,17 @@ func main() {
 		Writers:        []io.Writer{os.Stdout},
 	}
 
+	cfgfile := configPath
+	if runtime.GOOS == "windows" {
+		cfgfile = winConfigPath
+	}
+
+	var err error
+	config, err = parseConfig(cfgfile)
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Printf("Error parsing instance config %s: %s\n", cfgfile, err.Error())
+	}
+
 	// The keys to check vary based on the argument and the OS. Also functions to validate arguments.
 	wantedKeys, err := getWantedKeys(os.Args, runtime.GOOS)
 	if err != nil {
@@ -426,16 +437,6 @@ func main() {
 		opts.ProjectName = projectID
 	}
 	logger.Init(ctx, opts)
-
-	cfgfile := configPath
-	if runtime.GOOS == "windows" {
-		cfgfile = winConfigPath
-	}
-
-	config, err = parseConfig(cfgfile)
-	if err != nil && !os.IsNotExist(err) {
-		logger.Errorf("Error parsing instance config %s: %s", cfgfile, err)
-	}
 
 	logger.Infof("Starting %s scripts (version %s).", os.Args[1], version)
 

--- a/google_metadata_script_runner/main_test.go
+++ b/google_metadata_script_runner/main_test.go
@@ -1,0 +1,172 @@
+//  Copyright 2017 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestGetWantedArgs(t *testing.T) {
+	getWantedTests := []struct {
+		arg  string
+		os   string
+		want []string
+	}{
+		{
+			"specialize",
+			"windows",
+			[]string{
+				"sysprep-specialize-script-ps1",
+				"sysprep-specialize-script-cmd",
+				"sysprep-specialize-script-bat",
+				"sysprep-specialize-script-url",
+			},
+		},
+		{
+			"startup",
+			"windows",
+			[]string{
+				"windows-startup-script-ps1",
+				"windows-startup-script-cmd",
+				"windows-startup-script-bat",
+				"windows-startup-script-url",
+			},
+		},
+		{
+			"shutdown",
+			"windows",
+			[]string{
+				"windows-shutdown-script-ps1",
+				"windows-shutdown-script-cmd",
+				"windows-shutdown-script-bat",
+				"windows-shutdown-script-url",
+			},
+		},
+		{
+			"startup",
+			"linux",
+			[]string{
+				"startup-script-url",
+				"startup-script",
+			},
+		},
+		{
+			"shutdown",
+			"linux",
+			[]string{
+				"shutdown-script-url",
+				"shutdown-script",
+			},
+		},
+	}
+
+	for _, tt := range getWantedTests {
+		got, err := getWantedKeys([]string{"", tt.arg}, tt.os)
+		if err != nil {
+			t.Fatalf("validateArgs returned error: %v", err)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("returned slice does not match expected one: got %v, want %v", got, tt.want)
+		}
+		_, err = getWantedKeys([]string{""}, "")
+		if err == nil {
+			t.Errorf("0 args should produce an error")
+		}
+		_, err = getWantedKeys([]string{"", "", ""}, "")
+		if err == nil {
+			t.Errorf("3 args should produce an error")
+		}
+	}
+}
+
+func TestGetExistingKeys(t *testing.T) {
+	wantedKeys := []string{
+		"sysprep-specialize-script-cmd",
+		"sysprep-specialize-script-ps1",
+		"sysprep-specialize-script-bat",
+		"sysprep-specialize-script-url",
+	}
+	md := map[string]string{
+		"sysprep-specialize-script-cmd": "cmd",
+		"startup-script-cmd":            "cmd",
+		"shutdown-script-ps1":           "ps1",
+		"sysprep-specialize-script-url": "url",
+		"sysprep-specialize-script-ps1": "ps1",
+		"key":                           "value",
+		"sysprep-specialize-script-bat": "bat",
+	}
+	want := map[string]string{
+		"sysprep-specialize-script-ps1": "ps1",
+		"sysprep-specialize-script-cmd": "cmd",
+		"sysprep-specialize-script-bat": "bat",
+		"sysprep-specialize-script-url": "url",
+	}
+	got := parseMetadata(md, wantedKeys)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parsed metadata does not match expectation, got: %v, want: %v", got, want)
+	}
+}
+
+func TestParseGCS(t *testing.T) {
+	matchTests := []struct {
+		path, bucket, object string
+	}{
+		{"gs://bucket/object", "bucket", "object"},
+		{"gs://bucket/some/object", "bucket", "some/object"},
+		{"http://bucket.storage.googleapis.com/object", "bucket", "object"},
+		{"https://bucket.storage.googleapis.com/object", "bucket", "object"},
+		{"https://bucket.storage.googleapis.com/some/object", "bucket", "some/object"},
+		{"http://storage.googleapis.com/bucket/object", "bucket", "object"},
+		{"http://commondatastorage.googleapis.com/bucket/object", "bucket", "object"},
+		{"https://storage.googleapis.com/bucket/object", "bucket", "object"},
+		{"https://commondatastorage.googleapis.com/bucket/object", "bucket", "object"},
+		{"https://storage.googleapis.com/bucket/some/object", "bucket", "some/object"},
+		{"https://commondatastorage.googleapis.com/bucket/some/object", "bucket", "some/object"},
+	}
+
+	for _, tt := range matchTests {
+		bucket, object := parseGCS(tt.path)
+		if bucket != tt.bucket {
+			t.Errorf("returned bucket does not match expected one for %q:\n  got %q, want: %q", tt.path, bucket, tt.bucket)
+		}
+		if object != tt.object {
+			t.Errorf("returned object does not match expected one for %q\n:  got %q, want: %q", tt.path, object, tt.object)
+		}
+	}
+}
+
+func TestGetMetadata(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"key1":"value1","key2":"value2"}`)
+	}))
+	defer ts.Close()
+
+	metadataURL = ts.URL
+	metadataHang = ""
+
+	want := map[string]string{"key1": "value1", "key2": "value2"}
+	got, err := getMetadataAttributes("")
+	if err != nil {
+		t.Fatalf("error running getMetadataAttributes: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("metadata does not match expectation, got: %q, want: %q", got, want)
+	}
+}

--- a/google_metadata_script_runner/main_test.go
+++ b/google_metadata_script_runner/main_test.go
@@ -18,9 +18,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	config, _ = parseConfig("")
+	os.Exit(m.Run())
+}
 
 func TestGetWantedArgs(t *testing.T) {
 	getWantedTests := []struct {

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper (>= 9.20160709), dh-golang (>= 1.1), golang-go
 
 Package: google-guest-agent
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${misc:Depends}
+Conflicts: python-google-compute-engine, python3-google-compute-engine
 Description: Google Compute Engine Guest Agent
- Contains the guest agent as well as systemd startup scripts
+ Contains the guest agent and metadata script runner binaries.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -25,7 +25,15 @@ override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 
 override_dh_installinit:
-	dh_installinit --noscripts
+	# We don't ship sysvinit files or need script changes for them.
 
-override_dh_installsystemd:
-	dh_installsystemd --no-stop-on-upgrade
+override_dh_systemd_enable:
+	install -d debian/google-guest-agent/lib/systemd/system
+	install -p -m 0644 *.service debian/google-guest-agent/lib/systemd/system/
+	install -d debian/google-guest-agent/lib/systemd/system-preset
+	install -p -m 0644 *.preset debian/google-guest-agent/lib/systemd/system-preset/
+	dh_systemd_enable google-guest-agent.service google-startup-scripts.service google-shutdown-scripts.service
+
+override_dh_systemd_start:
+	# Only perform start/stop actions for the guest agent.
+	dh_systemd_start google-guest-agent.service

--- a/packaging/googet/google-compute-engine-metadata-scripts.goospec
+++ b/packaging/googet/google-compute-engine-metadata-scripts.goospec
@@ -8,7 +8,7 @@
   "files": {
     "google_metadata_script_runner/GCEMetadataScripts.exe": "<ProgramFiles>/Google/Compute Engine/metadata_scripts/GCEMetadataScripts.exe",
     "packaging/googet/run_shutdown_scripts.cmd": "<ProgramFiles>/Google/Compute Engine/metadata_scripts/run_shutdown_scripts.cmd",
-    "packaging/googet/run_startup_scripts.cmd": "<ProgramFiles>/Google/Compute Engine/metadata_scripts/run_startup_scripts.cmd",
+    "packaging/googet/run_startup_scripts.cmd": "<ProgramFiles>/Google/Compute Engine/metadata_scripts/run_startup_scripts.cmd"
   },
  "install": {
     "path": "packaging/googet/metadata_scripts_install.ps1"

--- a/packaging/googet/google-compute-engine-metadata-scripts.goospec
+++ b/packaging/googet/google-compute-engine-metadata-scripts.goospec
@@ -1,0 +1,43 @@
+{
+  "name": "google-compute-engine-metadata-scripts",
+  "version": "{{.version}}.0@1",
+  "arch": "x86_64",
+  "authors": "Google Inc.",
+  "license": "http://www.apache.org/licenses/LICENSE-2.0",
+  "description": "Google Compute Engine metadata scripts",
+  "files": {
+    "google_metadata_script_runner/GCEMetadataScripts.exe": "<ProgramFiles>/Google/Compute Engine/metadata_scripts/GCEMetadataScripts.exe",
+    "packaging/googet/run_shutdown_scripts.cmd": "<ProgramFiles>/Google/Compute Engine/metadata_scripts/run_shutdown_scripts.cmd",
+    "packaging/googet/run_startup_scripts.cmd": "<ProgramFiles>/Google/Compute Engine/metadata_scripts/run_startup_scripts.cmd",
+  },
+ "install": {
+    "path": "packaging/googet/metadata_scripts_install.ps1"
+  },
+  "uninstall": {
+    "path": "packaging/googet/metadata_scripts_uninstall.ps1"
+  },
+  "releaseNotes": [
+    "4.3.0 - Use guest logging library.",
+    "4.2.0 - Retry forever if metadata server is unavailable.",
+    "      - Honor project level metadata scripts.",
+    "4.1.6 - Add additional retry logic to account for slow network startup and transient GCS errors.",
+    "4.1.3 - Add a sleep in case DNS is not started at boot.",
+    "4.1.0 - Add startup and shutdown settings.",
+    "4.0.0 - Rewrite GCEMetadataScripts in Go.",
+    "3.5.0 - Separate metadata-scripts into its own package."
+  ],
+  "sources": [{
+      "include": [
+        "google_metadata_script_runner/GCEMetadataScripts.exe",
+        "packaging/googet/run_shutdown_scripts.cmd",
+        "packaging/googet/run_startup_scripts.cmd",
+        "packaging/googet/metadata_scripts_install.ps1",
+        "packaging/googet/metadata_scripts_uninstall.ps1"
+      ]
+  }],
+  "build": {
+    "linux": "/bin/bash",
+    "linuxArgs": ["-c", "GOOS=windows /tmp/go/bin/go build -ldflags '-X main.version={{.version}}' -mod=readonly -o ./google_metadata_script_runner/GCEMetadataScripts.exe ./google_metadata_script_runner"]
+  }
+}
+

--- a/packaging/googet/metadata_scripts_install.ps1
+++ b/packaging/googet/metadata_scripts_install.ps1
@@ -1,0 +1,54 @@
+#  Copyright 2017 Google Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+$install_dir = "${env:ProgramFiles}\Google\Compute Engine\metadata_scripts"
+$machine_env = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+
+$path = (Get-ItemProperty $machine_env).Path
+if ($path -notlike "*${install_dir}*") {
+  Set-ItemProperty $machine_env -Name 'Path' -Value ($path + ";${install_dir}")
+}
+
+$run_startup_scripts = "${install_dir}\run_startup_scripts.cmd"
+$service = New-Object -ComObject("Schedule.Service")
+$service.Connect()
+$task = $service.NewTask(0)
+$task.Settings.Enabled = $true
+$task.Settings.AllowDemandStart = $true
+$task.Settings.Priority = 5
+$action = $task.Actions.Create(0)
+$action.Path = "`"$run_startup_scripts`""
+$trigger = $task.Triggers.Create(8)
+$folder = $service.GetFolder('\')
+$folder.RegisterTaskDefinition('GCEStartup',$task,6,'System',$null,5) | Out-Null
+
+$gpt_ini = "${env:SystemRoot}\System32\GroupPolicy\gpt.ini"
+$scripts_ini = "${env:SystemRoot}\System32\GroupPolicy\Machine\Scripts\scripts.ini"
+if ((Test-Path $gpt_ini) -or (Test-Path $scripts_ini)) {
+  return
+}
+
+New-Item -Type Directory -Path "${env:SystemRoot}\System32\GroupPolicy\Machine\Scripts" -ErrorAction SilentlyContinue
+
+@'
+[General]
+gPCMachineExtensionNames= [{42B5FAAE-6536-11D2-AE5A-0000F87571E3}{40B6664F-4972-11D1-A7CA-0000F87571E3}]
+Version=1
+'@ | Set-Content -Path $gpt_ini -Encoding ASCII
+
+@'
+[Shutdown]
+0CmdLine=C:\Program Files\Google\Compute Engine\metadata_scripts\run_shutdown_scripts.cmd
+0Parameters=
+'@ | Set-Content -Path $scripts_ini -Encoding ASCII

--- a/packaging/googet/metadata_scripts_uninstall.ps1
+++ b/packaging/googet/metadata_scripts_uninstall.ps1
@@ -1,0 +1,23 @@
+#  Copyright 2017 Google Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+$install_dir = "${env:ProgramFiles}\Google\Compute Engine\metadata_scripts"
+$machine_env = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+
+$path = (Get-ItemProperty $machine_env).Path
+if ($path -like "*${install_dir}*") {
+  Set-ItemProperty $machine_env -Name 'Path' -Value $path.Replace(";$install_dir", '')
+}
+
+& schtasks /delete /tn GCEStartup /f

--- a/packaging/googet/run_shutdown_scripts.cmd
+++ b/packaging/googet/run_shutdown_scripts.cmd
@@ -1,0 +1,19 @@
+@echo off
+REM Copyright 2015 Google Inc. All Rights Reserved.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+REM Run shutdown scripts that should happen as soon as the instance
+REM begins to power down
+
+"C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "shutdown"

--- a/packaging/googet/run_startup_scripts.cmd
+++ b/packaging/googet/run_startup_scripts.cmd
@@ -1,0 +1,22 @@
+@echo off
+REM Copyright 2015 Google Inc. All Rights Reserved.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+REM Run startup scripts that should happen late at boot.
+
+REM A scheduled task may only run for up to three days before termination.
+REM We execute the startup script asynchronously so it may run without
+REM this three day maximum runtime limitation.
+
+start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "startup"

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -29,6 +29,8 @@ BuildArch: %{_arch}
 BuildRequires: systemd
 %endif
 
+Obsoletes: python-google-compute-engine, python3-google-compute-engine
+
 %description
 Contains the Google guest agent binary.
 
@@ -36,51 +38,125 @@ Contains the Google guest agent binary.
 %autosetup
 
 %build
-cd google_guest_agent
-GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_version}" -mod=readonly
+for bin in google_guest_agent google_metadata_script_runner; do
+  pushd "$bin"
+  GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_version}" -mod=readonly
+  popd
+done
 
 %install
 install -d %{buildroot}%{_bindir}
 install -p -m 0755 google_guest_agent/google_guest_agent %{buildroot}%{_bindir}/google_guest_agent
+install -p -m 0755 google_metadata_script_runner/google_metadata_script_runner %{buildroot}%{_bindir}/google_metadata_script_runner
 install -d %{buildroot}/usr/share/google-guest-agent
 install -p -m 0644 instance_configs.cfg %{buildroot}/usr/share/google-guest-agent/instance_configs.cfg
 %if 0%{?el6}
 install -d %{buildroot}/etc/init
-install -p -m 0644 %{name}.conf %{buildroot}/etc/init
+install -p -m 0644 %{name}.conf %{buildroot}/etc/init/
+install -p -m 0644 google-startup-scripts.conf %{buildroot}/etc/init/
+install -p -m 0644 google-shutdown-scripts.conf %{buildroot}/etc/init/
 %else
 install -d %{buildroot}%{_unitdir}
 install -d %{buildroot}%{_presetdir}
 install -p -m 0644 %{name}.service %{buildroot}%{_unitdir}
+install -p -m 0644 google-startup-scripts.service %{buildroot}%{_unitdir}
+install -p -m 0644 google-shutdown-scripts.service %{buildroot}%{_unitdir}
 install -p -m 0644 90-%{name}.preset %{buildroot}%{_presetdir}/90-%{name}.preset
 %endif
 
 %files
 %defattr(-,root,root,-)
+/usr/share/google-guest-agent/instance_configs.cfg
 %{_bindir}/google_guest_agent
+%{_bindir}/google_metadata_script_runner
 %if 0%{?el6}
 /etc/init/%{name}.conf
+/etc/init/google-startup-scripts.conf
+/etc/init/google-shutdown-scripts.conf
 %else
 %{_unitdir}/%{name}.service
+%{_unitdir}/google-startup-scripts.service
+%{_unitdir}/google-shutdown-scripts.service
 %{_presetdir}/90-%{name}.preset
 %endif
 
 %if ! 0%{?el6}
-
 %post
-%systemd_post google-guest-agent.service
 if [ $1 -eq 1 ]; then
+  # Initial installation
+
+  # Install instance configs if not already present.
   if [ ! -f /etc/default/instance_configs.cfg ]; then
     cp -a /usr/share/google-guest-agent/instance_configs.cfg /etc/default/
+  fi
+
+  # Use enable instead of preset because preset is not supported in
+  # chroots.
+  systemctl enable google-guest-agent.service >/dev/null 2>&1 || :
+  systemctl enable google-startup-scripts.service >/dev/null 2>&1 || :
+  systemctl enable google-shutdown-scripts.service >/dev/null 2>&1 || :
+
+  if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+    systemctl start google-guest-agent.service >/dev/null 2>&1 || :
+  fi
+else
+  # Package upgrade
+  if [ -d /run/systemd/system ]; then
+    systemctl try-restart google-guest-agent.service >/dev/null 2>&1 || :
   fi
 fi
 
 %preun
-%systemd_preun google-guest-agent.service
+if [ $1 -eq 0 ]; then
+  # Package removal, not upgrade
+  systemctl --no-reload disable google-guest-agent.service >/dev/null 2>&1 || :
+  systemctl --no-reload disable google-startup-scripts.service >/dev/null 2>&1 || :
+  systemctl --no-reload disable google-shutdown-scripts.service >/dev/null 2>&1 || :
+  if [-d /run/systemd/system ]; then
+    systemctl stop google-guest-agent.service >/dev/null 2>&1 || :
+  fi
+fi
 
 %postun
-%systemd_postun google-guest-agent.service
 if [ $1 -eq 0 ]; then
-  # Uninstall, not upgrade.
+  # Package removal, not upgrade
+
+  if [ -f /etc/default/instance_configs.cfg ]; then
+    rm /etc/default/instance_configs.cfg
+  fi
+
+  if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+  fi
+fi
+
+%else
+
+# EL6
+%post
+if [ $1 -eq 1 ]; then
+  # Install instance configs if not already present.
+  if [ ! -f /etc/default/instance_configs.cfg ]; then
+    cp -a /usr/share/google-guest-agent/instance_configs.cfg /etc/default/
+  fi
+
+  # Initial installation
+  initctl start google-guest-agent >/dev/null 2>&1 || :
+else
+  # Upgrade
+  initctl restart google-guest-agent >/dev/null 2>&1 || :
+fi
+
+%preun
+if [ $1 -eq 0 ]; then
+  # Package removal, not upgrade
+  initctl stop google-guest-agent >/dev/null 2>&1 || :
+fi
+
+%postun
+if [ $1 -eq 0 ]; then
+  # Package removal, not upgrade
   if [ -f /etc/default/instance_configs.cfg ]; then
     rm /etc/default/instance_configs.cfg
   fi


### PR DESCRIPTION
* Copy metadata runner from GoogleCloudPlatform/compute-image-windows
* Update RPM scriptlets and debian maintainer scripts
* Copy windows packaging and files to new locations
* Add config file support (step through commits to see these changes)

The windows packages will remain split as they are now, but the script runner will be shipped as part of the `google-guest-agent` package on linux. 