### PR TITLE
Instance config

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -263,7 +263,7 @@ func (a *addressMgr) disabled(os string) (disabled bool) {
 
 	// This is the linux config key, defaulting to true. On Linux, the
 	// config file has lower priority since we ship a file with defaults.
-	return config.Section("Daemons").Key("network_daemon").MustBool(true)
+	return !config.Section("Daemons").Key("network_daemon").MustBool(true)
 }
 
 func (a *addressMgr) set() error {
@@ -502,22 +502,22 @@ func enableNetworkInterfaces() error {
 		}
 		fallthrough
 	default:
-		dhcp_command := config.Section("NetworkInterfaces").Key("dhcp_command").String()
-		if dhcp_command != "" {
-			return runCmd(exec.Command(dhcp_command))
+		dhcpCommand := config.Section("NetworkInterfaces").Key("dhcp_command").String()
+		if dhcpCommand != "" {
+			return runCmd(exec.Command(dhcpCommand))
 		}
 
 		err := runCmd(exec.Command("dhclient", "-x"))
 		if err != nil {
 			logger.Warningf("Error running 'dhclient -x': %v.", err)
 		}
-		dhclient_args := []string{}
+		dhclientArgs := []string{}
 		// The dhclient_script key has historically only been supported on EL6.
 		if (osrelease.os == "rhel" || osrelease.os == "centos") && osrelease.version.major == 6 {
-			dhclient_args = append(dhclient_args, "-sf", config.Section("NetworkInterfaces").Key("dhclient_script").MustString("/sbin/google-dhclient-script"))
+			dhclientArgs = append(dhclientArgs, "-sf", config.Section("NetworkInterfaces").Key("dhclient_script").MustString("/sbin/google-dhclient-script"))
 		}
-		dhclient_args = append(dhclient_args, googleInterfaces...)
-		return runCmd(exec.Command("dhclient", dhclient_args...))
+		dhclientArgs = append(dhclientArgs, googleInterfaces...)
+		return runCmd(exec.Command("dhclient", dhclientArgs...))
 	}
 }
 

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -88,9 +88,9 @@ func (a *accountsMgr) timeout() bool {
 func (a *accountsMgr) disabled(os string) bool {
 	return false ||
 		os == "windows" ||
-		!config.Section("Daemons").Key("accounts_daemon").MustBool(true) ||
 		newMetadata.Instance.Attributes.EnableOSLogin ||
-		newMetadata.Project.Attributes.EnableOSLogin
+		newMetadata.Project.Attributes.EnableOSLogin ||
+		!config.Section("Daemons").Key("accounts_daemon").MustBool(true)
 }
 
 func (a *accountsMgr) set() error {

--- a/google_guest_agent/wsfc.go
+++ b/google_guest_agent/wsfc.go
@@ -52,7 +52,7 @@ func newWsfcManager() *wsfcManager {
 	newState := stopped
 
 	if func() bool {
-		enabled, err := config.Section("wsfc").Key("enabled").Bool()
+		enabled, err := config.Section("wsfc").Key("enable").Bool()
 		if err == nil {
 			return enabled
 		}

--- a/instance_configs.cfg
+++ b/instance_configs.cfg
@@ -1,4 +1,3 @@
-
 [Accounts]
 deprovision_remove = false
 gpasswd_add_cmd = gpasswd -a {user} {group}
@@ -7,12 +6,10 @@ groupadd_cmd = groupadd {group}
 groups = adm,dip,docker,lxd,plugdev,video
 useradd_cmd = useradd -m -s /bin/bash -p * {user}
 userdel_cmd = userdel -r {user}
-usermod_cmd = usermod -G {groups} {user}
 
 [Daemons]
 accounts_daemon = true
 clock_skew_daemon = true
-ip_forwarding_daemon = true
 network_daemon = true
 
 [InstanceSetup]


### PR DESCRIPTION
Add support for remaining instance config options
Deprecate the keys `usermod_cmd` and `ip_forwarding_daemon` in instance config