### PR TITLE
only use network-online.target

### DIFF
--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Google Compute Engine Guest Agent
-After=network-online.target network.target
-After=google-instance-setup.service After=rsyslog.service
 Before=sshd.service
+After=network-online.target rsyslog.service
+Wants=network-online.target
 PartOf=network.service
 
 [Service]


### PR DESCRIPTION
Matching changes to OSConfig, we should not use the network target but the network-online target, only.