### PR TITLE
Fix upstart,selinux

### DIFF
--- a/google-guest-agent.conf
+++ b/google-guest-agent.conf
@@ -1,5 +1,5 @@
-# Guest agent. Manages network interfaces, user accounts.
-start on stopped google-instance-setup
+description "GCE Guest Agent"
+start on stopped rc RUNLEVEL=[2345]
 oom -16
 
 respawn

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -157,7 +157,7 @@ func agentInit(ctx context.Context) error {
 					logger.Warningf("Failed to write instance ID file: %v", err)
 				}
 			}
-			if newMetadata.Instance.ID.String() != string(instanceID) {
+			if newMetadata.Instance.ID.String() != strings.TrimSuffix(string(instanceID), "\n") {
 				logger.Infof("Instance ID changed, running first-boot actions")
 				if config.Section("InstanceSetup").Key("set_host_keys").MustBool(true) {
 					if err := generateSSHKeys(); err != nil {

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -157,7 +157,7 @@ func agentInit(ctx context.Context) error {
 					logger.Warningf("Failed to write instance ID file: %v", err)
 				}
 			}
-			if newMetadata.Instance.ID.String() != strings.TrimSuffix(string(instanceID), "\n") {
+			if newMetadata.Instance.ID.String() != strings.TrimSpace(string(instanceID)) {
 				logger.Infof("Instance ID changed, running first-boot actions")
 				if config.Section("InstanceSetup").Key("set_host_keys").MustBool(true) {
 					if err := generateSSHKeys(); err != nil {

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -476,5 +476,6 @@ func updateAuthorizedKeysFile(user string, keys []string) error {
 		os.Remove(tempPath)
 		return fmt.Errorf("error setting ownership of new keys file: %v", err)
 	}
+	runCmd(exec.Command("restorecon", tempPath))
 	return os.Rename(tempPath, akpath)
 }


### PR DESCRIPTION
* Change upstart init to not rely on google-instance-setup (deprecated)
* Instance ID comparisons should strip newlines
* Run restorecon on authorized_keys files