### PR TITLE
amend upstart again to be before hostkeys

### DIFF
--- a/google-guest-agent.conf
+++ b/google-guest-agent.conf
@@ -1,5 +1,5 @@
 description "GCE Guest Agent"
-start on stopped rc RUNLEVEL=[2345]
+start on started rsyslog
 oom -16
 
 respawn


### PR DESCRIPTION
this is actually equivalent to what legacy instance setup depended on, and has an impact on hostkey generation. to avoid any surprise to users, match what we had before.