### PR TITLE
Avoid setting route on Teredo Pseudo-Interface

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -75,7 +75,8 @@ func agentInit(ctx context.Context) error {
 
 		for _, iface := range interfaces {
 			// Only take action on interfaces that are up, are not Loopback, and are not vEtherent (commonly setup by docker).
-			if strings.Contains(iface.Name, "vEthernet") || iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			if strings.Contains(iface.Name, "vEthernet") || strings.Contains(iface.Name, "Teredo Tunneling") ||
+				iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
 				continue
 			}
 


### PR DESCRIPTION
2020/02/06 04:27:25 GCEGuestAgent: GCE Agent Started (version 20200129.00)
2020/02/06 04:27:25 GCEGuestAgent: Adding route to metadata server on "Teredo Tunneling Pseudo-Interface" (index: 3)
2020/02/06 04:27:25 GCEGuestAgent: Error adding route to metadata server on "Teredo Tunneling Pseudo-Interface" (index: 3): nonzero return code from CreateIpForwardEntry: Element not found.