### PR TITLE
correct SSH key handling

### DIFF
--- a/google_guest_agent/accounts_test.go
+++ b/google_guest_agent/accounts_test.go
@@ -202,10 +202,12 @@ func TestRemoveExpiredKeys(t *testing.T) {
 	}{
 		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0000"}`, true},
 		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0700"}`, true},
+		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0700", "futureField": "UNUSED_FIELDS_IGNORED"}`, true},
 		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2018-11-08T19:30:46+0000"}`, false},
 		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2018-11-08T19:30:46+0700"}`, false},
-		{`user:ssh-rsa [KEY] hostname`, true},
+		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"INVALID_TIMESTAMP"}`, false},
 		{`user:ssh-rsa [KEY] google-ssh`, false},
+		{`user:ssh-rsa [KEY] user`, true},
 		{`user:ssh-rsa [KEY]`, true},
 		{},
 	}

--- a/google_guest_agent/accounts_test.go
+++ b/google_guest_agent/accounts_test.go
@@ -206,7 +206,7 @@ func TestRemoveExpiredKeys(t *testing.T) {
 		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2018-11-08T19:30:46+0700"}`, false},
 		{`user:ssh-rsa [KEY] hostname`, true},
 		{`user:ssh-rsa [KEY] google-ssh`, false},
-		{`user:ssh-rsa [KEY]`, false},
+		{`user:ssh-rsa [KEY]`, true},
 		{},
 	}
 

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -297,8 +297,9 @@ func (k linuxKey) expired() bool {
 // removeExpiredKeys returns the provided list of keys with expired keys removed.
 // valid formats are:
 // ssh-rsa [KEY_VALUE] [USERNAME]
-// or
+// ssh-rsa [KEY_VALUE]
 // ssh-rsa [KEY_VALUE] google-ssh {"userName":"[USERNAME]","expireOn":"[EXPIRE_TIME]"}
+//
 // see: https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat
 func removeExpiredKeys(keys []string) []string {
 	var res []string
@@ -308,10 +309,7 @@ func removeExpiredKeys(keys []string) []string {
 			continue
 		}
 		fields := strings.SplitN(key, " ", 4)
-		if len(fields) < 3 {
-			continue
-		}
-		if fields[2] != "google-ssh" {
+		if len(fields) < 3 || fields[2] != "google-ssh" {
 			// non-expiring key, add it.
 			res = append(res, key)
 			continue


### PR DESCRIPTION
[Public GCE docs](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#sshkeyformat) reference the following as a valid SSH key format:
```
ssh-rsa [KEY_VALUE] [USERNAME]
```

However, the legacy guest environment supports also:
```
ssh-rsa [KEY_VALUE]
```

Correct the filtering done in `removeExpiredKeys()` not to skip keys in this format. Update tests to accomodate it.