### PR TITLE
Bugfixes

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -85,16 +85,24 @@ func getForwardsFromRegistry(mac string) ([]string, error) {
 	return regFwdIPs, nil
 }
 
-func compareIPs(configuredIPs, desiredIPs []string) (toAdd, toRm []string) {
-	for _, desiredIP := range desiredIPs {
-		if !containsString(desiredIP, configuredIPs) {
-			toAdd = append(toAdd, desiredIP)
+func compareRoutes(configuredRoutes, desiredRoutes []string) (toAdd, toRm []string) {
+	for _, desiredRoute := range desiredRoutes {
+		if !strings.Contains(desiredRoute, "/") {
+			logger.Errorf("requested route %q missing mask, skipping.", desiredRoute)
+			continue
+		}
+		if !containsString(desiredRoute, configuredRoutes) {
+			toAdd = append(toAdd, desiredRoute)
 		}
 	}
 
-	for _, configuredIP := range configuredIPs {
-		if !containsString(configuredIP, desiredIPs) {
-			toRm = append(toRm, configuredIP)
+	for _, configuredRoute := range configuredRoutes {
+		if !strings.Contains(configuredRoute, "/") {
+			logger.Errorf("local route %q missing mask, skipping.", configuredRoute)
+			continue
+		}
+		if !containsString(configuredRoute, desiredRoutes) {
+			toRm = append(toRm, configuredRoute)
 		}
 	}
 	return toAdd, toRm
@@ -348,7 +356,7 @@ func (a *addressMgr) set() error {
 			}
 		}
 
-		toAdd, toRm := compareIPs(forwardedIPs, wantIPs)
+		toAdd, toRm := compareRoutes(forwardedIPs, wantIPs)
 
 		if len(toAdd) != 0 || len(toRm) != 0 {
 			var msg string

--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -143,6 +143,9 @@ func getLocalRoutes(ifname string) ([]string, error) {
 		line = strings.TrimPrefix(line, "local ")
 		line = strings.TrimSpace(line)
 		if line != "" {
+			if !strings.Contains(line, "/") {
+				line = line + "/32"
+			}
 			res = append(res, line)
 		}
 	}
@@ -280,7 +283,8 @@ func (a *addressMgr) set() error {
 	if config.Section("NetworkInterfaces").Key("setup").MustBool(true) {
 		if runtime.GOOS != "windows" {
 			if err := configureIPv6(); err != nil {
-				return err
+				// Continue through IPv6 configuration errors.
+				logger.Errorf("Error configuring IPv6: %v", err)
 			}
 		}
 

--- a/google_guest_agent/addresses_test.go
+++ b/google_guest_agent/addresses_test.go
@@ -22,28 +22,28 @@ import (
 	"github.com/go-ini/ini"
 )
 
-func TestCompareIPs(t *testing.T) {
+func TestCompareRoutes(t *testing.T) {
 	var tests = []struct {
 		forwarded, metadata, wantAdd, wantRm []string
 	}{
 		// These should return toAdd:
 		// In Md, not present
-		{nil, []string{"1.2.3.4"}, []string{"1.2.3.4"}, nil},
-		{nil, []string{"1.2.3.4", "5.6.7.8"}, []string{"1.2.3.4", "5.6.7.8"}, nil},
+		{nil, []string{"1.2.3.4/32"}, []string{"1.2.3.4/32"}, nil},
+		{nil, []string{"1.2.3.4/32", "5.6.7.8/32"}, []string{"1.2.3.4/32", "5.6.7.8/32"}, nil},
 
 		// These should return toRm:
 		// Present, not in Md
-		{[]string{"1.2.3.4"}, nil, nil, []string{"1.2.3.4"}},
-		{[]string{"1.2.3.4", "5.6.7.8"}, []string{"5.6.7.8"}, nil, []string{"1.2.3.4"}},
+		{[]string{"1.2.3.4/32"}, nil, nil, []string{"1.2.3.4/32"}},
+		{[]string{"1.2.3.4/32", "5.6.7.8/32"}, []string{"5.6.7.8/32"}, nil, []string{"1.2.3.4/32"}},
 
 		// These should return nil, nil:
 		// Present, in Md
-		{[]string{"1.2.3.4"}, []string{"1.2.3.4"}, nil, nil},
-		{[]string{"1.2.3.4", "5.6.7.8"}, []string{"1.2.3.4", "5.6.7.8"}, nil, nil},
+		{[]string{"1.2.3.4/32"}, []string{"1.2.3.4/32"}, nil, nil},
+		{[]string{"1.2.3.4/32", "5.6.7.8/32"}, []string{"1.2.3.4/32", "5.6.7.8/32"}, nil, nil},
 	}
 
 	for idx, tt := range tests {
-		toAdd, toRm := compareIPs(tt.forwarded, tt.metadata)
+		toAdd, toRm := compareRoutes(tt.forwarded, tt.metadata)
 		if !reflect.DeepEqual(tt.wantAdd, toAdd) {
 			t.Errorf("case %d: toAdd does not match expected: forwarded: %q, metadata: %q, got: %q, want: %q", idx, tt.forwarded, tt.metadata, toAdd, tt.wantAdd)
 		}

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -113,7 +113,7 @@ if [ $1 -eq 0 ]; then
   systemctl --no-reload disable google-guest-agent.service >/dev/null 2>&1 || :
   systemctl --no-reload disable google-startup-scripts.service >/dev/null 2>&1 || :
   systemctl --no-reload disable google-shutdown-scripts.service >/dev/null 2>&1 || :
-  if [-d /run/systemd/system ]; then
+  if [ -d /run/systemd/system ]; then
     systemctl stop google-guest-agent.service >/dev/null 2>&1 || :
   fi
 fi


### PR DESCRIPTION
3 bugfixes identified during software rollout
* IP forwarding comparison incorrectly considered '1.1.1.1' and '1.1.1.1/32' to be different
* errors calling dhclient for IPv6 would return and prevent the remainder of network setup from running
* rpm spec %preun typo caused agent not to be stopped on uninstall

behavior before IP forwarding fix:
```
$ ip route list table local type local scope host dev eth0 proto 66
local 10.138.0.104 
$ sudo systemctl restart google-guest-agent                        
$ ip route list table local type local scope host dev eth0 proto 66
$ sudo systemctl restart google-guest-agent                        
$ ip route list table local type local scope host dev eth0 proto 66
local 10.138.0.104 
```

behavior as of this PR:
```
$ ip route list table local type local scope host dev eth0 proto 66
local 10.138.0.104 
$ sudo systemctl restart google-guest-agent
$ ip route list table local type local scope host dev eth0 proto 66
local 10.138.0.104 
$ sudo systemctl restart google-guest-agent
$ ip route list table local type local scope host dev eth0 proto 66
local 10.138.0.104 
```