### PR TITLE
Windows: Fix the quoting for binpath in Set-ServiceConfig

### DIFF
--- a/packaging/googet/agent_install.ps1
+++ b/packaging/googet/agent_install.ps1
@@ -33,7 +33,7 @@ function Set-ServiceConfig {
   # Restart service after 1s, then 2s. Reset error counter after 60s.
   sc.exe failure $name reset= 60 actions= restart/1000/restart/2000
   # Set dependency and delayed start
-  sc.exe config $name depend= "samss" start= delayed-auto binpath= $path
+  cmd.exe /c "sc.exe config ${name} depend= `"samss`" start= delayed-auto binpath= \`"${path}\`""
   # Create trigger to start the service on first IP address
   sc.exe triggerinfo $name start/networkon
 }


### PR DESCRIPTION
The binpath needs to retain the quotes, to do this with sc.exe the quotes need to be escaped, this is not simple to do in powershell so we just take the easy route and run it through cmd.exe