### PR TITLE
Enable diagnostics tool by default for GA 

### DIFF
--- a/google_guest_agent/diagnostics.go
+++ b/google_guest_agent/diagnostics.go
@@ -28,7 +28,7 @@ const diagnosticsCmd = `C:\Program Files\Google\Compute Engine\diagnostics\diagn
 
 var (
 	diagnosticsRegKey   = "Diagnostics"
-	diagnosticsDisabled = true
+	diagnosticsDisabled = false
 )
 
 type diagnosticsEntry struct {
@@ -70,7 +70,7 @@ func (d *diagnosticsMgr) disabled(os string) (disabled bool) {
 		}
 	}()
 
-	// Diagnostics are opt-in and disabled by default.
+	// Diagnostics are opt-in and enabled by default.
 	var err error
 	var enabled bool
 	enabled, err = strconv.ParseBool(config.Section("diagnostics").Key("enable").String())

--- a/google_guest_agent/diagnostics_test.go
+++ b/google_guest_agent/diagnostics_test.go
@@ -46,7 +46,7 @@ func TestDiagnosticsDisabled(t *testing.T) {
 		md   *metadata
 		want bool
 	}{
-		{"not explicitly enabled", []byte(""), &metadata{}, true},
+		{"not explicitly enabled", []byte(""), &metadata{}, false},
 		{"enabled in cfg only", []byte("[diagnostics]\nenable=true"), &metadata{}, false},
 		{"disabled in cfg only", []byte("[diagnostics]\nenable=false"), &metadata{}, true},
 		{"disabled in cfg, enabled in instance metadata", []byte("[diagnostics]\nenable=false"), &metadata{Instance: instance{Attributes: attributes{EnableDiagnostics: mkptr(true)}}}, true},


### PR DESCRIPTION
To use [diagnostics tool](go/vanadium/guest_os/guest_diagnostics_tool#run-gcloud-cli-to-collect-logs), Users need to 
1) enable `roles/iam.serviceAccountTokenCreator` for their project.
2) enable `enable-diagnostics` metadata flag.
3) trigger the gcloud command to start.

From PM, TL and customer voices, step 2 seems unneeded, we decided to remove the `enable-diagnostics` flag for customer experience and gain more usage for GA.
