### PR TITLE
Fix the diagnostics tool's trace functionality

### DIFF
--- a/google_guest_agent/diagnostics.go
+++ b/google_guest_agent/diagnostics.go
@@ -34,7 +34,7 @@ var (
 type diagnosticsEntry struct {
 	SignedURL string
 	ExpireOn  string
-	TraceFlag bool
+	Trace     bool
 }
 
 func (k diagnosticsEntry) expired() bool {
@@ -112,7 +112,7 @@ func (d *diagnosticsMgr) set() error {
 		"-signedUrl",
 		entry.SignedURL,
 	}
-	if entry.TraceFlag {
+	if entry.Trace {
 		args = append(args, "-trace")
 	}
 


### PR DESCRIPTION
The diagnostics tool's [trace functionality ](https://cloud.google.com/compute/docs/instances/collecting-diagnostic-information#collecting_diagnostic_information_from_a_vm)is broken, because diagnostics metadata value is `{"expireOn": "2020-06-05T10:19:03Z", "signedUrl": "xxx", "trace": true}`, there's no traceFlag field, so the trace flag value got lost after unmarshaling. Fix the field name to match with the json struct.