### PR TITLE
oslogin: dont add entry to pam.d/su

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -259,17 +259,6 @@ func updatePAMsshd(pamsshd string, enable, twofactor bool) string {
 	return strings.Join(filtered, "\n")
 }
 
-func updatePAMsu(pamsu string, enable bool) string {
-	accountSu := "account    [success=bad ignore=ignore] pam_oslogin_login.so"
-
-	filtered := filterGoogleLines(pamsu)
-	if enable {
-		filtered = append([]string{googleComment, accountSu}, filtered...)
-	}
-
-	return strings.Join(filtered, "\n")
-}
-
 func writePAMConfig(enable, twofactor bool) error {
 	pamsshd, err := ioutil.ReadFile("/etc/pam.d/sshd")
 	if err != nil {
@@ -278,17 +267,6 @@ func writePAMConfig(enable, twofactor bool) error {
 	proposed := updatePAMsshd(string(pamsshd), enable, twofactor)
 	if proposed != string(pamsshd) {
 		if err := writeConfigFile("/etc/pam.d/sshd", proposed); err != nil {
-			return err
-		}
-	}
-
-	pamsu, err := ioutil.ReadFile("/etc/pam.d/su")
-	if err != nil {
-		return err
-	}
-	proposed = updatePAMsu(string(pamsu), enable)
-	if proposed != string(pamsu) {
-		if err := writeConfigFile("/etc/pam.d/su", proposed); err != nil {
 			return err
 		}
 	}

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -354,65 +354,6 @@ func TestUpdatePAMsshd(t *testing.T) {
 		}
 	}
 }
-func TestUpdatePAMsu(t *testing.T) {
-	accountSu := "account    [success=bad ignore=ignore] pam_oslogin_login.so"
-
-	var tests = []struct {
-		contents, want []string
-		enable         bool
-	}{
-		{
-			contents: []string{
-				"line1",
-				"line2",
-			},
-			want: []string{
-				googleComment,
-				accountSu,
-				"line1",
-				"line2",
-			},
-			enable: true,
-		},
-		{
-			contents: []string{
-				"line1",
-				googleComment,
-				accountSu,
-				"line2",
-			},
-			want: []string{
-				googleComment,
-				accountSu,
-				"line1",
-				"line2",
-			},
-			enable: true,
-		},
-		{
-			contents: []string{
-				"line1",
-				googleComment,
-				accountSu,
-				"line2",
-			},
-			want: []string{
-				"line1",
-				"line2",
-			},
-			enable: false,
-		},
-	}
-
-	for idx, tt := range tests {
-		contents := strings.Join(tt.contents, "\n")
-		want := strings.Join(tt.want, "\n")
-
-		if res := updatePAMsu(contents, tt.enable); res != want {
-			t.Errorf("test %v\nwant:\n%v\ngot:\n%v\n", idx, want, res)
-		}
-	}
-}
 
 func TestUpdateGroupConf(t *testing.T) {
 	config := "sshd;*;*;Al0000-2400;video"


### PR DESCRIPTION
Remove the blocking module from the `su` PAM config. OS Login users are instead going to have a locked password, so this isn't needed.