### PR TITLE
Fix metric for addIPForwardEntry

### DIFF
--- a/google_guest_agent/addresses_windows.go
+++ b/google_guest_agent/addresses_windows.go
@@ -287,15 +287,15 @@ func addIPForwardEntry(fe ipForwardEntry) error {
 		dwForwardPolicy:    0, // unused
 		dwForwardNextHop:   binary.LittleEndian.Uint32(fe.ipForwardNextHop.To4()),
 		dwForwardIfIndex:   IF_INDEX(fe.ipForwardIfIndex),
-		dwForwardType:      0, // unused
+		dwForwardType:      MIB_IPROUTE_TYPE_INDIRECT, // unused
 		dwForwardProto:     MIB_IPPROTO_NETMGMT,
-		dwForwardAge:       0,                                         // unused
-		dwForwardNextHopAS: 0,                                         // unused
-		dwForwardMetric1:   fe.ipForwardMetric1 + fe.ipForwardIfIndex, // See remarks.
-		dwForwardMetric2:   -1,                                        // unused
-		dwForwardMetric3:   -1,                                        // unused
-		dwForwardMetric4:   -1,                                        // unused
-		dwForwardMetric5:   -1,                                        // unused
+		dwForwardAge:       0, // unused
+		dwForwardNextHopAS: 0, // unused
+		dwForwardMetric1:   fe.ipForwardMetric1,
+		dwForwardMetric2:   -1, // unused
+		dwForwardMetric3:   -1, // unused
+		dwForwardMetric4:   -1, // unused
+		dwForwardMetric5:   -1, // unused
 	}
 
 	if ret, _, _ := procCreateIpForwardEntry.Call(uintptr(unsafe.Pointer(fr))); ret != 0 {

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -60,10 +60,12 @@ func agentInit(ctx context.Context) {
 		// This is equivalent to how route.exe works when interface is not provided.
 		var index int32
 		var found bool
+		var metric int32
 		sort.Slice(fes, func(i, j int) bool { return fes[i].ipForwardIfIndex < fes[j].ipForwardIfIndex })
 		for _, fe := range fes {
 			if fe.ipForwardDest.Equal(net.ParseIP("0.0.0.0")) {
 				index = fe.ipForwardIfIndex
+				metric = fe.ipForwardMetric1
 				found = true
 				break
 			}
@@ -80,16 +82,23 @@ func agentInit(ctx context.Context) {
 			return
 		}
 
-		fe := ipForwardEntry{
+		forwardEntry := ipForwardEntry{
 			ipForwardDest:    net.ParseIP("169.254.169.254"),
 			ipForwardMask:    net.IPv4Mask(255, 255, 255, 255),
 			ipForwardNextHop: net.ParseIP("0.0.0.0"),
-			ipForwardMetric1: 1,
+			ipForwardMetric1: metric, // This needs to be at least equal to the default route metric.
 			ipForwardIfIndex: int32(iface.Index),
 		}
 
+		for _, fe := range fes {
+			if fe.ipForwardDest.Equal(forwardEntry.ipForwardDest) && fe.ipForwardIfIndex == forwardEntry.ipForwardIfIndex {
+				// No need to add entry, it's already setup.
+				return
+			}
+		}
+
 		logger.Infof("Adding route to metadata server on %q (index: %d)", iface.Name, iface.Index)
-		if err := addIPForwardEntry(fe); err != nil {
+		if err := addIPForwardEntry(forwardEntry); err != nil {
 			logger.Errorf("%s, error adding IPForwardEntry on %q (index: %d): %v", msg, iface.Name, iface.Index, err)
 			return
 		}


### PR DESCRIPTION
The route metric needs to be at least equal to the default route metric, the microsoft documentation is very confusing when describing this.
Don't attempt to re-add route to metadata if it already exists.