### PR TITLE
update agent systemd service file

### DIFF
--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Google Compute Engine Guest Agent
 Before=sshd.service
-After=network-online.target rsyslog.service
+After=network-online.target rsyslog.service network.service networking.service
+After=NetworkManager.service
 Wants=network-online.target
-PartOf=network.service
+PartOf=network.service networking.service NetworkManager.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
We add the network service to the `PartOf=` option to support restarting the agent when the network is restarted.

This service is known as `network.service` on some systems and `networking.service` on others. Some distributions don't have either, but only the `NetworkManager.service` unit.

Also, adding the service to the `After=` option may help ordering such that (for example) newly added routes aren't immediately wiped out, as in the case where the guest agent restarts first and the network restarts second. 