### PR TITLE
getPasswd: Check full prefix of line for username

### DIFF
--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -198,7 +198,7 @@ func getPasswd(user string) (*passwdEntry, error) {
 	colon := []byte{':'}
 
 	parse := func(line []byte) (*passwdEntry, error) {
-		if !bytes.Contains(line, prefix) || bytes.Count(line, colon) < 6 {
+		if !bytes.HasPrefix(line, prefix) || bytes.Count(line, colon) < 6 {
 			return nil, nil
 		}
 		// kevin:x:1005:1006::/home/kevin:/usr/bin/zsh


### PR DESCRIPTION
This fixes #80 where the username is checked with Contains, resulting in improper parsing when a username is a suffix of another username.