### PR TITLE
do not overwrite ifcfg files on SLES

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -534,7 +534,12 @@ func enableSLESInterfaces(interfaces []string) error {
 	var priority = 10100
 	for _, iface := range interfaces {
 		var ifcfg *os.File
-		ifcfg, err = os.Create("/etc/sysconfig/network/ifcfg-" + iface)
+		filename := "/etc/sysconfig/network/ifcfg-" + iface
+		_, err = os.Stat(filename)
+		if ! os.IsNotExist(err) {
+			return nil
+		}
+		ifcfg, err = os.Create(filename)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
On SLES, the guest agent always writes an ifcfg file for any secondary NIC regardless whether there is one already. This makes it impossible to use a deviating configuration. This PR adds a check whether an ifcfg file for the interface that is being set up already exists and skips setup if that is the case.