### PR TITLE
Introduce struct to hold agent configuration values and print them on start

### DIFF
--- a/google_guest_agent/accounts_test.go
+++ b/google_guest_agent/accounts_test.go
@@ -76,14 +76,18 @@ func TestAccountsDisabled(t *testing.T) {
 	for _, tt := range tests {
 		cfg, err := ini.InsensitiveLoad(tt.data)
 		if err != nil {
-			t.Errorf("test case %q: error parsing config: %v", tt.name, err)
+			t.Errorf("test case %q: error parsing ini data: %v", tt.name, err)
 			continue
 		}
 		if cfg == nil {
 			cfg = &ini.File{}
 		}
 		newMetadata = tt.md
-		config = cfg
+		config, err = parseIni(cfg)
+		if err != nil {
+			t.Errorf("test case %q: error parsing config: %v", tt.name, err)
+			continue
+		}
 		got := (&winAccountsMgr{}).disabled("windows")
 		if got != tt.want {
 			t.Errorf("test case %q, accounts.disabled() got: %t, want: %t", tt.name, got, tt.want)

--- a/google_guest_agent/accounts_unix.go
+++ b/google_guest_agent/accounts_unix.go
@@ -33,7 +33,7 @@ func getUID(path string) string {
 }
 
 func createUser(username, uid string) error {
-	useradd := config.raw.Section("Accounts").Key("useradd_cmd").MustString("useradd -m -s /bin/bash -p * {user}")
+	useradd := config.Accounts.UseraddCmd
 	if uid != "" {
 		useradd = fmt.Sprintf("%s -u %s", useradd, uid)
 	}
@@ -41,7 +41,7 @@ func createUser(username, uid string) error {
 }
 
 func addUserToGroup(user, group string) error {
-	gpasswdadd := config.raw.Section("Accounts").Key("gpasswd_add_cmd").MustString("gpasswd -a {user} {group}")
+	gpasswdadd := config.Accounts.GpasswdAddCmd
 	return runCmd(createUserGroupCmd(gpasswdadd, user, group))
 }
 

--- a/google_guest_agent/accounts_unix.go
+++ b/google_guest_agent/accounts_unix.go
@@ -33,7 +33,7 @@ func getUID(path string) string {
 }
 
 func createUser(username, uid string) error {
-	useradd := config.Section("Accounts").Key("useradd_cmd").MustString("useradd -m -s /bin/bash -p * {user}")
+	useradd := config.raw.Section("Accounts").Key("useradd_cmd").MustString("useradd -m -s /bin/bash -p * {user}")
 	if uid != "" {
 		useradd = fmt.Sprintf("%s -u %s", useradd, uid)
 	}
@@ -41,7 +41,7 @@ func createUser(username, uid string) error {
 }
 
 func addUserToGroup(user, group string) error {
-	gpasswdadd := config.Section("Accounts").Key("gpasswd_add_cmd").MustString("gpasswd -a {user} {group}")
+	gpasswdadd := config.raw.Section("Accounts").Key("gpasswd_add_cmd").MustString("gpasswd -a {user} {group}")
 	return runCmd(createUserGroupCmd(gpasswdadd, user, group))
 }
 

--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -244,7 +244,7 @@ func (a *addressMgr) timeout() bool {
 }
 
 func (a *addressMgr) disabled(os string) (disabled bool) {
-        if config.AddressManager.ExplicitlyConfigured {
+	if config.AddressManager.ExplicitlyConfigured {
 		// This is the windows config key. On windows, finding a key in
 		// the config file takes priority over metadata.
 		return config.AddressManager.Disable

--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -41,7 +41,7 @@ var (
 type addressMgr struct{}
 
 func (a *addressMgr) parseWSFCAddresses() string {
-	wsfcAddresses := config.raw.Section("wsfc").Key("addresses").String()
+	wsfcAddresses := config.Wsfc.Addresses
 	if wsfcAddresses != "" {
 		return wsfcAddresses
 	}
@@ -56,9 +56,8 @@ func (a *addressMgr) parseWSFCAddresses() string {
 }
 
 func (a *addressMgr) parseWSFCEnable() bool {
-	wsfcEnable, err := config.raw.Section("wsfc").Key("enable").Bool()
-	if err == nil {
-		return wsfcEnable
+	if config.Wsfc.ExplicitlyConfigured {
+		return config.Wsfc.Enable
 	}
 	if newMetadata.Instance.Attributes.EnableWSFC != nil {
 		return *newMetadata.Instance.Attributes.EnableWSFC

--- a/google_guest_agent/clock.go
+++ b/google_guest_agent/clock.go
@@ -32,7 +32,7 @@ func (a *clockskewMgr) timeout() bool {
 }
 
 func (a *clockskewMgr) disabled(os string) (disabled bool) {
-	enabled := config.Section("Daemons").Key("clock_skew_daemon").MustBool(true)
+	enabled := config.raw.Section("Daemons").Key("clock_skew_daemon").MustBool(true)
 	return os == "windows" || !enabled
 }
 

--- a/google_guest_agent/clock.go
+++ b/google_guest_agent/clock.go
@@ -32,7 +32,7 @@ func (a *clockskewMgr) timeout() bool {
 }
 
 func (a *clockskewMgr) disabled(os string) (disabled bool) {
-	enabled := config.raw.Section("Daemons").Key("clock_skew_daemon").MustBool(true)
+	enabled := config.Daemons.ClockSkewDaemon
 	return os == "windows" || !enabled
 }
 

--- a/google_guest_agent/config.go
+++ b/google_guest_agent/config.go
@@ -97,7 +97,6 @@ type WsfcConfig struct {
 }
 
 type AgentConfig struct {
-	raw               *ini.File
 	AccountManager    AccountManagerConfig
 	Accounts          AccountsConfig
 	AddressManager    AddressManagerConfig
@@ -222,7 +221,6 @@ func (c AgentConfig) String() string {
 // always be used instead.
 func parseIni(iniFile *ini.File) (AgentConfig, error) {
 	config := defaultConfig
-	config.raw = iniFile
 	config.AccountManager.ExplicitlyConfigured = iniFile.Section("accountManager").HasKey("disable")
 	config.AddressManager.ExplicitlyConfigured = iniFile.Section("addressManager").HasKey("disable")
 	config.Wsfc.ExplicitlyConfigured = iniFile.Section("wsfc").HasKey("enable")

--- a/google_guest_agent/config.go
+++ b/google_guest_agent/config.go
@@ -16,10 +16,19 @@ package main
 
 import (
 	"github.com/go-ini/ini"
+	"strings"
 )
 
+type WsfcConfig struct {
+	ExplicitlyConfigured bool
+	Enable               bool
+	Addresses            string
+	Port                 string
+}
+
 type AgentConfig struct {
-	raw *ini.File
+	raw  *ini.File
+	Wsfc WsfcConfig
 }
 
 var defaultConfig = AgentConfig{
@@ -39,7 +48,11 @@ var defaultConfig = AgentConfig{
 // - UpperCamelCase field maps to UpperCamelCase key
 //   e.g. InstanceSetup maps to InstanceSetup
 var agentConfigNameMapper = func(raw string) string {
-	return raw
+	if raw == "Wsfc" {
+		return strings.ToLower(string(raw[0])) + string(raw[1:])
+	} else {
+		return ini.TitleUnderscore(raw)
+	}
 }
 
 // parseIni is only exposed for testing. parseConfig should almost
@@ -47,6 +60,7 @@ var agentConfigNameMapper = func(raw string) string {
 func parseIni(iniFile *ini.File) (AgentConfig, error) {
 	config := defaultConfig
 	config.raw = iniFile
+	config.Wsfc.ExplicitlyConfigured = iniFile.Section("wsfc").HasKey("enable")
 	iniFile.NameMapper = agentConfigNameMapper
 	iniFile.StrictMapTo(&config)
 	return config, nil

--- a/google_guest_agent/config.go
+++ b/google_guest_agent/config.go
@@ -1,0 +1,62 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"github.com/go-ini/ini"
+)
+
+type AgentConfig struct {
+	raw *ini.File
+}
+
+var defaultConfig = AgentConfig{
+	raw: ini.Empty(),
+}
+
+// agentConfigNameMapper is used to map field names in the AgentConfig
+// to keys in an INI configuration file. Ideally, we would use a built
+// in standard NameMapper like ini.TitleUnderscore (which maps fields
+// from UpperCamelCase to lower_with_underscores), but unfortunately
+// the mapping is slightly inconsistent.
+// We have three possible ways a field can be mapped to a key:
+// - UpperCamelCase field maps to lower_with_underscores key
+//   e.g. SnapshotServicePort maps to snapshot_service_port
+// - UpperCamelCase field maps to lowerCamelCase key
+//   e.g. AccountManager maps to accountManager
+// - UpperCamelCase field maps to UpperCamelCase key
+//   e.g. InstanceSetup maps to InstanceSetup
+var agentConfigNameMapper = func(raw string) string {
+	return raw
+}
+
+// parseIni is only exposed for testing. parseConfig should almost
+// always be used instead.
+func parseIni(iniFile *ini.File) (AgentConfig, error) {
+	config := defaultConfig
+	config.raw = iniFile
+	iniFile.NameMapper = agentConfigNameMapper
+	iniFile.StrictMapTo(&config)
+	return config, nil
+}
+
+func parseConfig(file string) (AgentConfig, error) {
+	// Priority: file.cfg, file.cfg.distro, file.cfg.template
+	iniFile, err := ini.LoadSources(ini.LoadOptions{Loose: true, Insensitive: true}, file, file+".distro", file+".template")
+	if err != nil {
+		return defaultConfig, err
+	}
+	return parseIni(iniFile)
+}

--- a/google_guest_agent/config.go
+++ b/google_guest_agent/config.go
@@ -19,6 +19,10 @@ import (
 	"strings"
 )
 
+type DaemonsConfig struct {
+	ClockSkewDaemon bool
+}
+
 type WsfcConfig struct {
 	ExplicitlyConfigured bool
 	Enable               bool
@@ -27,12 +31,16 @@ type WsfcConfig struct {
 }
 
 type AgentConfig struct {
-	raw  *ini.File
-	Wsfc WsfcConfig
+	raw     *ini.File
+	Daemons DaemonsConfig
+	Wsfc    WsfcConfig
 }
 
 var defaultConfig = AgentConfig{
 	raw: ini.Empty(),
+	Daemons: DaemonsConfig{
+		ClockSkewDaemon: true,
+	},
 }
 
 // agentConfigNameMapper is used to map field names in the AgentConfig
@@ -50,6 +58,8 @@ var defaultConfig = AgentConfig{
 var agentConfigNameMapper = func(raw string) string {
 	if raw == "Wsfc" {
 		return strings.ToLower(string(raw[0])) + string(raw[1:])
+	} else if raw == "Daemons" {
+		return raw
 	} else {
 		return ini.TitleUnderscore(raw)
 	}

--- a/google_guest_agent/config.go
+++ b/google_guest_agent/config.go
@@ -50,6 +50,21 @@ type DiagnosticsConfig struct {
 	Enable string
 }
 
+type InstanceConfig struct {
+	InstanceIdDir string
+	InstanceId    string
+}
+
+type InstanceSetupConfig struct {
+	OptimizeLocalSsd bool
+	SetMultiqueue    bool
+	NetworkEnabled   bool
+	HostKeyDir       string
+	HostKeyTypes     string
+	SetBotoConfig    bool
+	SetHostKeys      bool
+}
+
 type IpForwardingConfig struct {
 	EthernetProtoId   string
 	TargetInstanceIps bool
@@ -86,6 +101,8 @@ type AgentConfig struct {
 	AddressManager    AddressManagerConfig
 	Daemons           DaemonsConfig
 	Diagnostics       DiagnosticsConfig
+	Instance          InstanceConfig
+	InstanceSetup     InstanceSetupConfig
 	IpForwarding      IpForwardingConfig
 	NetworkInterfaces NetworkInterfacesConfig
 	Snapshots         SnapshotsConfig
@@ -107,6 +124,18 @@ var defaultConfig = AgentConfig{
 		ClockSkewDaemon: true,
 		AccountsDaemon:  true,
 		NetworkDaemon:   true,
+	},
+	Instance: InstanceConfig{
+		InstanceIdDir: "/etc",
+	},
+	InstanceSetup: InstanceSetupConfig{
+		OptimizeLocalSsd: true,
+		SetMultiqueue:    true,
+		NetworkEnabled:   true,
+		HostKeyDir:       "/etc/ssh",
+		HostKeyTypes:     "ecdsa,ed25519,rsa",
+		SetBotoConfig:    true,
+		SetHostKeys:      true,
 	},
 	IpForwarding: IpForwardingConfig{
 		EthernetProtoId:   "66",
@@ -145,6 +174,8 @@ var agentConfigNameMapper = func(raw string) string {
 		return strings.ToLower(string(raw[0])) + string(raw[1:])
 	} else if raw == "Accounts" ||
 		raw == "Daemons" ||
+		raw == "Instance" ||
+		raw == "InstanceSetup" ||
 		raw == "IpForwarding" ||
 		raw == "NetworkInterfaces" ||
 		raw == "Snapshots" {

--- a/google_guest_agent/config.go
+++ b/google_guest_agent/config.go
@@ -23,6 +23,10 @@ type DaemonsConfig struct {
 	ClockSkewDaemon bool
 }
 
+type DiagnosticsConfig struct {
+	Enable string
+}
+
 type WsfcConfig struct {
 	ExplicitlyConfigured bool
 	Enable               bool
@@ -31,9 +35,10 @@ type WsfcConfig struct {
 }
 
 type AgentConfig struct {
-	raw     *ini.File
-	Daemons DaemonsConfig
-	Wsfc    WsfcConfig
+	raw         *ini.File
+	Daemons     DaemonsConfig
+	Diagnostics DiagnosticsConfig
+	Wsfc        WsfcConfig
 }
 
 var defaultConfig = AgentConfig{
@@ -56,7 +61,8 @@ var defaultConfig = AgentConfig{
 // - UpperCamelCase field maps to UpperCamelCase key
 //   e.g. InstanceSetup maps to InstanceSetup
 var agentConfigNameMapper = func(raw string) string {
-	if raw == "Wsfc" {
+	if raw == "Diagnostics" ||
+		raw == "Wsfc" {
 		return strings.ToLower(string(raw[0])) + string(raw[1:])
 	} else if raw == "Daemons" {
 		return raw

--- a/google_guest_agent/config.go
+++ b/google_guest_agent/config.go
@@ -44,6 +44,15 @@ type DiagnosticsConfig struct {
 	Enable string
 }
 
+type SnapshotsConfig struct {
+	Enabled             bool
+	SnapshotServiceIp   string
+	SnapshotServicePort int
+	TimeoutInSeconds    int
+	PreSnapshotScript   string
+	PostSnapshotScript  string
+}
+
 type WsfcConfig struct {
 	ExplicitlyConfigured bool
 	Enable               bool
@@ -57,6 +66,7 @@ type AgentConfig struct {
 	Accounts       AccountsConfig
 	Daemons        DaemonsConfig
 	Diagnostics    DiagnosticsConfig
+	Snapshots      SnapshotsConfig
 	Wsfc           WsfcConfig
 }
 
@@ -75,6 +85,11 @@ var defaultConfig = AgentConfig{
 	Daemons: DaemonsConfig{
 		ClockSkewDaemon: true,
 		AccountsDaemon:  true,
+	},
+	Snapshots: SnapshotsConfig{
+		SnapshotServiceIp:   "169.254.169.254",
+		SnapshotServicePort: 8081,
+		TimeoutInSeconds:    60,
 	},
 }
 
@@ -96,7 +111,8 @@ var agentConfigNameMapper = func(raw string) string {
 		raw == "Wsfc" {
 		return strings.ToLower(string(raw[0])) + string(raw[1:])
 	} else if raw == "Accounts" ||
-		raw == "Daemons" {
+		raw == "Daemons" ||
+		raw == "Snapshots" {
 		return raw
 	} else {
 		return ini.TitleUnderscore(raw)

--- a/google_guest_agent/config_test.go
+++ b/google_guest_agent/config_test.go
@@ -1,0 +1,28 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestEnsureDefaultConfigLoads(t *testing.T) {
+	configFile := "../instance_configs.cfg"
+	_, err := parseConfig(configFile)
+	if err != nil {
+		t.Errorf("Error parsing config %s: %s", configFile, err)
+	}
+}
+

--- a/google_guest_agent/config_test.go
+++ b/google_guest_agent/config_test.go
@@ -16,7 +16,24 @@ package main
 
 import (
 	"testing"
+
+	"github.com/go-ini/ini"
 )
+
+func TestEnsureIpForwardingConfigurationLoaded(t *testing.T) {
+	iniConfig := []byte("[NetworkInterfaces]\nip_forwarding: false\n")
+	iniFile, err := ini.InsensitiveLoad(iniConfig)
+	if err != nil {
+		t.Errorf("Error parsing ini data: %v", err)
+	}
+	config, err := parseIni(iniFile)
+	if err != nil {
+		t.Errorf("Error parsing config %s: %s", iniConfig, err)
+	}
+	if config.NetworkInterfaces.IpForwarding != false {
+		t.Errorf("Error loading NetworkInterfaces.IpForwarding value")
+	}
+}
 
 func TestEnsureDefaultConfigLoads(t *testing.T) {
 	configFile := "../instance_configs.cfg"

--- a/google_guest_agent/config_test.go
+++ b/google_guest_agent/config_test.go
@@ -25,4 +25,3 @@ func TestEnsureDefaultConfigLoads(t *testing.T) {
 		t.Errorf("Error parsing config %s: %s", configFile, err)
 	}
 }
-

--- a/google_guest_agent/config_test.go
+++ b/google_guest_agent/config_test.go
@@ -25,3 +25,53 @@ func TestEnsureDefaultConfigLoads(t *testing.T) {
 		t.Errorf("Error parsing config %s: %s", configFile, err)
 	}
 }
+
+func TestAgentConfigNameMapper(t *testing.T) {
+	var tests = []struct {
+		name            string
+		expectedMapping string
+	}{
+		{"Accounts", "Accounts"},
+		{"ReuseHomedir", "reuse_homedir"},
+		{"Groups", "groups"},
+		{"DeprovisionRemove", "deprovision_remove"},
+		{"UserdelCmd", "userdel_cmd"},
+		{"GpasswdRemoveCmd", "gpasswd_remove_cmd"},
+		{"GpasswdAddCmd", "gpasswd_add_cmd"},
+		{"GroupaddCmd", "groupadd_cmd"},
+		{"UseraddCmd", "useradd_cmd"},
+		{"Daemons", "Daemons"},
+		{"ClockSkewDaemon", "clock_skew_daemon"},
+		{"AccountsDaemon", "accounts_daemon"},
+		{"NetworkDaemon", "network_daemon"},
+		{"Instance", "Instance"},
+		{"InstanceIdDir", "instance_id_dir"},
+		{"InstanceSetup", "InstanceSetup"},
+		{"OptimizeLocalSsd", "optimize_local_ssd"},
+		{"SetMultiqueue", "set_multiqueue"},
+		{"NetworkEnabled", "network_enabled"},
+		{"HostKeyDir", "host_key_dir"},
+		{"HostKeyTypes", "host_key_types"},
+		{"SetBotoConfig", "set_boto_config"},
+		{"SetHostKeys", "set_host_keys"},
+		{"IpForwarding", "IpForwarding"},
+		{"EthernetProtoId", "ethernet_proto_id"},
+		{"TargetInstanceIps", "target_instance_ips"},
+		{"IpAliases", "ip_aliases"},
+		{"NetworkInterfaces", "NetworkInterfaces"},
+		{"Setup", "setup"},
+		{"IpForwarding", "IpForwarding"},
+		{"DhclientScript", "dhclient_script"},
+		{"Snapshots", "Snapshots"},
+		{"SnapshotServiceIp", "snapshot_service_ip"},
+		{"SnapshotServicePort", "snapshot_service_port"},
+		{"TimeoutInSeconds", "timeout_in_seconds"},
+	}
+
+	for _, tt := range tests {
+		mapping := agentConfigNameMapper(tt.name)
+		if mapping != tt.expectedMapping {
+			t.Errorf("Got '%s' instead of expected mapping '%s' for '%s'", mapping, tt.expectedMapping, tt.name)
+		}
+	}
+}

--- a/google_guest_agent/config_test.go
+++ b/google_guest_agent/config_test.go
@@ -20,10 +20,11 @@ import (
 
 func TestEnsureDefaultConfigLoads(t *testing.T) {
 	configFile := "../instance_configs.cfg"
-	_, err := parseConfig(configFile)
+	config, err := parseConfig(configFile)
 	if err != nil {
 		t.Errorf("Error parsing config %s: %s", configFile, err)
 	}
+	t.Logf("Config:%s", config)
 }
 
 func TestAgentConfigNameMapper(t *testing.T) {

--- a/google_guest_agent/diagnostics.go
+++ b/google_guest_agent/diagnostics.go
@@ -77,7 +77,7 @@ func (d *diagnosticsMgr) disabled(os string) (disabled bool) {
 	// Diagnostics are opt-in and enabled by default.
 	var err error
 	var enabled bool
-	enabled, err = strconv.ParseBool(config.Section("diagnostics").Key("enable").String())
+	enabled, err = strconv.ParseBool(config.raw.Section("diagnostics").Key("enable").String())
 	if err == nil {
 		return !enabled
 	}

--- a/google_guest_agent/diagnostics.go
+++ b/google_guest_agent/diagnostics.go
@@ -77,7 +77,7 @@ func (d *diagnosticsMgr) disabled(os string) (disabled bool) {
 	// Diagnostics are opt-in and enabled by default.
 	var err error
 	var enabled bool
-	enabled, err = strconv.ParseBool(config.raw.Section("diagnostics").Key("enable").String())
+	enabled, err = strconv.ParseBool(config.Diagnostics.Enable)
 	if err == nil {
 		return !enabled
 	}

--- a/google_guest_agent/diagnostics_test.go
+++ b/google_guest_agent/diagnostics_test.go
@@ -61,14 +61,18 @@ func TestDiagnosticsDisabled(t *testing.T) {
 	for _, tt := range tests {
 		cfg, err := ini.InsensitiveLoad(tt.data)
 		if err != nil {
-			t.Errorf("test case %q: error parsing config: %v", tt.name, err)
+			t.Errorf("test case %q: error parsing ini file: %v", tt.name, err)
 			continue
 		}
 		if cfg == nil {
 			cfg = &ini.File{}
 		}
 		newMetadata = tt.md
-		config = cfg
+		config, err = parseIni(cfg)
+		if err != nil {
+			t.Errorf("test case %q: error parsing config: %v", tt.name, err)
+			continue
+		}
 		got := (&diagnosticsMgr{}).disabled("windows")
 		if got != tt.want {
 			t.Errorf("test case %q, diagnostics.disabled() got: %t, want: %t", tt.name, got, tt.want)

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -114,11 +114,14 @@ func agentInit(ctx context.Context) {
 		}
 
 		// These scripts are run regardless of metadata/network access and config options.
-		for _, script := range []string{"optimize_local_ssd", "set_multiqueue"} {
-			if config.raw.Section("InstanceSetup").Key(script).MustBool(true) {
-				if err := runCmd(exec.Command("google_" + script)); err != nil {
-					logger.Warningf("Failed to run %q script: %v", "google_"+script, err)
-				}
+		if config.InstanceSetup.SetMultiqueue {
+			if err := runCmd(exec.Command("google_set_multiqueue")); err != nil {
+				logger.Warningf("Failed to run %q script: %v", "google_set_multiqueue", err)
+			}
+		}
+		if config.InstanceSetup.OptimizeLocalSsd {
+			if err := runCmd(exec.Command("google_optimize_local_ssd")); err != nil {
+				logger.Warningf("Failed to run %q script: %v", "google_optimize_local_ssd", err)
 			}
 		}
 
@@ -131,7 +134,7 @@ func agentInit(ctx context.Context) {
 		}
 
 		// Allow users to opt out of below instance setup actions.
-		if !config.raw.Section("InstanceSetup").Key("network_enabled").MustBool(true) {
+		if !config.InstanceSetup.NetworkEnabled {
 			logger.Infof("InstanceSetup.network_enabled is false, skipping setup actions that require metadata")
 			return
 		}
@@ -156,14 +159,14 @@ func agentInit(ctx context.Context) {
 		// Check if instance ID has changed, and if so, consider this
 		// the first boot of the instance.
 		// TODO Also do this for windows. liamh@13-11-2019
-		instanceIDFile := config.raw.Section("Instance").Key("instance_id_dir").MustString("/etc") + "/google_instance_id"
+		instanceIDFile := config.Instance.InstanceIdDir + "/google_instance_id"
 		instanceID, err := ioutil.ReadFile(instanceIDFile)
 		if err != nil && !os.IsNotExist(err) {
 			logger.Warningf("Not running first-boot actions, error reading instance ID: %v", err)
 		} else {
 			if string(instanceID) == "" {
 				// If the file didn't exist or was empty, try legacy key from instance configs.
-				instanceID = []byte(config.raw.Section("Instance").Key("instance_id").String())
+				instanceID = []byte(config.Instance.InstanceId)
 
 				// Write instance ID to file for next time before moving on.
 				towrite := fmt.Sprintf("%s\n", newMetadata.Instance.ID.String())
@@ -173,12 +176,12 @@ func agentInit(ctx context.Context) {
 			}
 			if newMetadata.Instance.ID.String() != strings.TrimSpace(string(instanceID)) {
 				logger.Infof("Instance ID changed, running first-boot actions")
-				if config.raw.Section("InstanceSetup").Key("set_host_keys").MustBool(true) {
+				if config.InstanceSetup.SetHostKeys {
 					if err := generateSSHKeys(); err != nil {
 						logger.Warningf("Failed to generate SSH keys: %v", err)
 					}
 				}
-				if config.raw.Section("InstanceSetup").Key("set_boto_config").MustBool(true) {
+				if config.InstanceSetup.SetBotoConfig {
 					if err := generateBotoConfig(); err != nil {
 						logger.Warningf("Failed to create boto.cfg: %v", err)
 					}
@@ -196,7 +199,7 @@ func agentInit(ctx context.Context) {
 }
 
 func generateSSHKeys() error {
-	hostKeyDir := config.raw.Section("InstanceSetup").Key("host_key_dir").MustString("/etc/ssh")
+	hostKeyDir := config.InstanceSetup.HostKeyDir
 	dir, err := os.Open(hostKeyDir)
 	if err != nil {
 		return err
@@ -223,7 +226,7 @@ func generateSSHKeys() error {
 	}
 
 	// List keys we should generate, according to the config.
-	configKeys := config.raw.Section("InstanceSetup").Key("host_key_types").MustString("ecdsa,ed25519,rsa")
+	configKeys := config.InstanceSetup.HostKeyTypes
 	for _, keytype := range strings.Split(configKeys, ",") {
 		keytypes[keytype] = true
 	}

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -106,10 +106,10 @@ func agentInit(ctx context.Context) {
 	} else {
 		// Linux instance setup.
 
-		if config.raw.Section("Snapshots").Key("enabled").MustBool(false) {
+		if config.Snapshots.Enabled {
 			logger.Infof("Snapshot listener enabled")
-			snapshotServiceIP := config.raw.Section("Snapshots").Key("snapshot_service_ip").MustString("169.254.169.254")
-			snapshotServicePort := config.raw.Section("Snapshots").Key("snapshot_service_port").MustInt(8081)
+			snapshotServiceIP := config.Snapshots.SnapshotServiceIp
+			snapshotServicePort := config.Snapshots.SnapshotServicePort
 			startSnapshotListener(snapshotServiceIP, snapshotServicePort)
 		}
 

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
-	"github.com/go-ini/ini"
 	"github.com/tarm/serial"
 )
 
@@ -39,7 +38,7 @@ var (
 	version                  string
 	ticker                   = time.Tick(70 * time.Second)
 	oldMetadata, newMetadata *metadata
-	config                   *ini.File
+	config                   AgentConfig
 	osRelease                release
 	action                   string
 )
@@ -81,15 +80,6 @@ func logStatus(name string, disabled bool) {
 		status = "disabled"
 	}
 	logger.Infof("GCE %s manager status: %s", name, status)
-}
-
-func parseConfig(file string) (*ini.File, error) {
-	// Priority: file.cfg, file.cfg.distro, file.cfg.template
-	cfg, err := ini.LoadSources(ini.LoadOptions{Loose: true, Insensitive: true}, file, file+".distro", file+".template")
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 func closeFile(c io.Closer) {

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -148,6 +148,8 @@ func run(ctx context.Context) {
 		logger.Errorf("Error parsing config %s: %s", cfgfile, err)
 	}
 
+	logger.Infof("GCE Agent Config Loaded:\n%s", config)
+
 	agentInit(ctx)
 
 	go func() {

--- a/google_guest_agent/snapshot_listener.go
+++ b/google_guest_agent/snapshot_listener.go
@@ -48,9 +48,9 @@ func (e *invalidSnapshotConfig) Error() string {
 
 func getSnapshotConfig() (snapshotConfig, error) {
 	var conf snapshotConfig
-	conf.timeout = time.Duration(config.raw.Section("Snapshots").Key("timeout_in_seconds").MustInt(60)) * time.Second
-	conf.preSnapshotScriptURL = config.raw.Section("Snapshots").Key("pre_snapshot_script").String()
-	conf.postSnapshotScriptURL = config.raw.Section("Snapshots").Key("post_snapshot_script").String()
+	conf.timeout = time.Duration(config.Snapshots.TimeoutInSeconds) * time.Second
+	conf.preSnapshotScriptURL = config.Snapshots.PreSnapshotScript
+	conf.postSnapshotScriptURL = config.Snapshots.PostSnapshotScript
 
 	if conf.preSnapshotScriptURL == "" && conf.postSnapshotScriptURL == "" {
 		return conf, &invalidSnapshotConfig{"neither pre or post snapshot script has been configured"}

--- a/google_guest_agent/snapshot_listener.go
+++ b/google_guest_agent/snapshot_listener.go
@@ -48,9 +48,9 @@ func (e *invalidSnapshotConfig) Error() string {
 
 func getSnapshotConfig() (snapshotConfig, error) {
 	var conf snapshotConfig
-	conf.timeout = time.Duration(config.Section("Snapshots").Key("timeout_in_seconds").MustInt(60)) * time.Second
-	conf.preSnapshotScriptURL = config.Section("Snapshots").Key("pre_snapshot_script").String()
-	conf.postSnapshotScriptURL = config.Section("Snapshots").Key("post_snapshot_script").String()
+	conf.timeout = time.Duration(config.raw.Section("Snapshots").Key("timeout_in_seconds").MustInt(60)) * time.Second
+	conf.preSnapshotScriptURL = config.raw.Section("Snapshots").Key("pre_snapshot_script").String()
+	conf.postSnapshotScriptURL = config.raw.Section("Snapshots").Key("post_snapshot_script").String()
 
 	if conf.preSnapshotScriptURL == "" && conf.postSnapshotScriptURL == "" {
 		return conf, &invalidSnapshotConfig{"neither pre or post snapshot script has been configured"}

--- a/google_guest_agent/windows_accounts.go
+++ b/google_guest_agent/windows_accounts.go
@@ -204,9 +204,8 @@ func (a *winAccountsMgr) disabled(os string) (disabled bool) {
 		return true
 	}
 
-	disabled, err := config.raw.Section("accountManager").Key("disable").Bool()
-	if err == nil {
-		return disabled
+	if config.AccountManager.ExplicitlyConfigured {
+		return config.AccountManager.Disable
 	}
 	if newMetadata.Instance.Attributes.DisableAccountManager != nil {
 		return *newMetadata.Instance.Attributes.DisableAccountManager

--- a/google_guest_agent/windows_accounts.go
+++ b/google_guest_agent/windows_accounts.go
@@ -204,7 +204,7 @@ func (a *winAccountsMgr) disabled(os string) (disabled bool) {
 		return true
 	}
 
-	disabled, err := config.Section("accountManager").Key("disable").Bool()
+	disabled, err := config.raw.Section("accountManager").Key("disable").Bool()
 	if err == nil {
 		return disabled
 	}

--- a/google_guest_agent/wsfc.go
+++ b/google_guest_agent/wsfc.go
@@ -52,11 +52,10 @@ func newWsfcManager() *wsfcManager {
 	newState := stopped
 
 	if func() bool {
-		enabled, err := config.raw.Section("wsfc").Key("enable").Bool()
-		if err == nil {
-			return enabled
+		if config.Wsfc.ExplicitlyConfigured {
+			return config.Wsfc.Enable
 		}
-		if config.raw.Section("wsfc").Key("addresses").String() != "" {
+		if config.Wsfc.Addresses != "" {
 			return true
 		}
 		if newMetadata.Instance.Attributes.EnableWSFC != nil {
@@ -77,7 +76,7 @@ func newWsfcManager() *wsfcManager {
 	}
 
 	newPort := wsfcDefaultAgentPort
-	port := config.raw.Section("wsfc").Key("port").String()
+	port := config.Wsfc.Port
 	if port != "" {
 		newPort = port
 	} else if newMetadata.Instance.Attributes.WSFCAgentPort != "" {

--- a/google_guest_agent/wsfc.go
+++ b/google_guest_agent/wsfc.go
@@ -52,11 +52,11 @@ func newWsfcManager() *wsfcManager {
 	newState := stopped
 
 	if func() bool {
-		enabled, err := config.Section("wsfc").Key("enable").Bool()
+		enabled, err := config.raw.Section("wsfc").Key("enable").Bool()
 		if err == nil {
 			return enabled
 		}
-		if config.Section("wsfc").Key("addresses").String() != "" {
+		if config.raw.Section("wsfc").Key("addresses").String() != "" {
 			return true
 		}
 		if newMetadata.Instance.Attributes.EnableWSFC != nil {
@@ -77,7 +77,7 @@ func newWsfcManager() *wsfcManager {
 	}
 
 	newPort := wsfcDefaultAgentPort
-	port := config.Section("wsfc").Key("port").String()
+	port := config.raw.Section("wsfc").Key("port").String()
 	if port != "" {
 		newPort = port
 	} else if newMetadata.Instance.Attributes.WSFCAgentPort != "" {

--- a/google_guest_agent/wsfc_test.go
+++ b/google_guest_agent/wsfc_test.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"reflect"
 	"testing"
-
-	"github.com/go-ini/ini"
 )
 
 func setEnableWSFC(md metadata, enabled *bool) *metadata {
@@ -60,7 +58,7 @@ func TestNewWsfcManager(t *testing.T) {
 		{"wsfc addrs is set", args{setWSFCAddresses(testMetadata, "0.0.0.0")}, &wsfcManager{agentNewState: running, agentNewPort: wsfcDefaultAgentPort, agent: testAgent}},
 		{"wsfc port is set", args{setWSFCAgentPort(testMetadata, "1818")}, &wsfcManager{agentNewState: stopped, agentNewPort: "1818", agent: testAgent}},
 	}
-	config = ini.Empty()
+	config = defaultConfig
 	for _, tt := range tests {
 		newMetadata = tt.args.newMetadata
 		if got := newWsfcManager(); !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
This change introduces the AgentConfig struct. It consolidates configuration values into a single location, which makes it easier to inspect those values at runtime. We now print those configuration values on agent start.

This fixes #85.

This is a large change, so I broke it up into discrete commits that can be reviewed individually. Hopefully that makes it a bit easier :-)