### PR TITLE
Include startup and shutdown in preset

### DIFF
--- a/90-google-guest-agent.preset
+++ b/90-google-guest-agent.preset
@@ -1,1 +1,3 @@
 enable google-guest-agent.service
+enable google-shutdown-scripts.service
+enable google-startup-scripts.service


### PR DESCRIPTION
This change supports upstreaming to Fedora.

It'll be a no-op for our build, since  `%post` enables the services:

https://github.com/GoogleCloudPlatform/guest-agent/blob/master/packaging/google-guest-agent.spec#L97