### PR TITLE
add a match block to sshd_config for SAs

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -171,6 +171,8 @@ func updateSSHConfig(sshConfig string, enable, twofactor bool) string {
 		authorizedKeysUser = "AuthorizedKeysCommandRunAs root"
 		twoFactorAuthMethods = "RequiredAuthentications2 publickey,keyboard-interactive"
 	}
+	matchblock1 := `Match User sa_*`
+	matchblock2 := `       AuthenticationMethods publickey`
 
 	filtered := filterGoogleLines(string(sshConfig))
 
@@ -181,6 +183,9 @@ func updateSSHConfig(sshConfig string, enable, twofactor bool) string {
 		}
 		osLoginBlock = append(osLoginBlock, googleBlockEnd)
 		filtered = append(osLoginBlock, filtered...)
+		if twofactor {
+			filtered = append(filtered, googleBlockStart, matchblock1, matchblock2, googleBlockEnd)
+		}
 	}
 
 	return strings.Join(filtered, "\n")

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -184,6 +184,8 @@ func TestUpdateSSHConfig(t *testing.T) {
 	authorizedKeysCommand := "AuthorizedKeysCommand /usr/bin/google_authorized_keys"
 	authorizedKeysUser := "AuthorizedKeysCommandUser root"
 	twoFactorAuthMethods := "AuthenticationMethods publickey,keyboard-interactive"
+	matchblock1 := `Match User sa_*`
+	matchblock2 := `       AuthenticationMethods publickey`
 
 	var tests = []struct {
 		contents, want    []string
@@ -205,6 +207,10 @@ func TestUpdateSSHConfig(t *testing.T) {
 				challengeResponseEnable,
 				googleBlockEnd,
 				"line1",
+				googleBlockStart,
+				matchblock1,
+				matchblock2,
+				googleBlockEnd,
 			},
 			enable:    true,
 			twofactor: true,
@@ -226,6 +232,10 @@ func TestUpdateSSHConfig(t *testing.T) {
 				googleBlockEnd,
 				"line1",
 				"line3",
+				googleBlockStart,
+				matchblock1,
+				matchblock2,
+				googleBlockEnd,
 			},
 			enable:    true,
 			twofactor: true,


### PR DESCRIPTION
don't require keyboard-interactive as a required authentication method for service accounts