### PR TITLE
Enable creating Google users with GID.

### DIFF
--- a/google_guest_agent/accounts_windows.go
+++ b/google_guest_agent/accounts_windows.go
@@ -137,7 +137,7 @@ func addUserToGroup(username, group string) error {
 	return nil
 }
 
-func createUser(username, pwd string) error {
+func createUser(username, pwd, _ string) error {
 	uPtr, err := syscall.UTF16PtrFromString(username)
 	if err != nil {
 		return fmt.Errorf("error encoding username to UTF16: %v", err)
@@ -183,6 +183,6 @@ func userExists(name string) (bool, error) {
 	return true, nil
 }
 
-func getUID(path string) string {
-	return ""
+func getUIDAndGID(path string) (string, string) {
+	return "", ""
 }

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -345,12 +345,12 @@ func createUserGroupCmd(cmd, user, group string) *exec.Cmd {
 // createGoogleUser creates a Google managed user account if needed and adds it
 // to the configured groups.
 func createGoogleUser(user string) error {
-	var uid string
+	var uid, gid string
 	if config.Section("Accounts").Key("reuse_homedir").MustBool(false) {
-		uid = getUID(fmt.Sprintf("/home/%s", user))
+		uid, gid = getUIDAndGID(fmt.Sprintf("/home/%s", user))
 	}
 
-	if err := createUser(user, uid); err != nil {
+	if err := createUser(user, uid, gid); err != nil {
 		return err
 	}
 	groups := config.Section("Accounts").Key("groups").MustString("adm,dip,docker,lxd,plugdev,video")

--- a/google_guest_agent/windows_accounts.go
+++ b/google_guest_agent/windows_accounts.go
@@ -139,7 +139,7 @@ func (k windowsKey) createOrResetPwd() (*credsJSON, error) {
 		}
 	} else {
 		logger.Infof("Creating user %s", k.UserName)
-		if err := createUser(k.UserName, pwd); err != nil {
+		if err := createUser(k.UserName, pwd, ""); err != nil {
 			return nil, fmt.Errorf("error running createUser: %v", err)
 		}
 		if k.AddToAdministrators == nil || *k.AddToAdministrators == true {


### PR DESCRIPTION
On COS, /home is stateful but /etc is stateless. So on reboots, all the
users are wiped but their home directories persist. A previous commit
was submitted to create a new user with the UID of their home directory
if it already exists. We need to also create the user with the GID of
their home directory, since it is not necessarily the case that the
UID == GID for a given user.