### PR TITLE
Update error message for handleHealthCheckRequest

### DIFF
--- a/google_guest_agent/wsfc.go
+++ b/google_guest_agent/wsfc.go
@@ -203,7 +203,7 @@ func (a *wsfcAgent) handleHealthCheckRequest(conn net.Conn) {
 	// Read the incoming connection into the buffer.
 	reqLen, err := conn.Read(buf)
 	if err != nil {
-		logger.Errorf("wsfc - error on processing request: %s", err)
+		logger.Errorf("wsfc - error on processing tcp request for network heartbeat health check: %s", err)
 		return
 	}
 


### PR DESCRIPTION
# PR Summary
---
This PR updates one of the error message for the `handleHealthCheckRequest` function to address the recommended feedback from the internal issue tracker. Previously, the error message was less clear about the type of failed request. The updated message uses matching wording as the GCE public document: [Running Windows Server Failover Clustering](https://cloud.google.com/compute/docs/tutorials/running-windows-server-failover-clustering#create_firewall_rules_for_the_health_check). The update message will help users to troubleshoot network related issues and adjust to correct course.

Thank you.

