### PR TITLE
more granular service restarts

### DIFF
--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -184,7 +184,7 @@ func (a *accountsMgr) set() error {
 	// can be disabled by the instance configs file.
 	for _, svc := range []string{"ssh", "sshd"} {
 		// Ignore output, it's just a best effort.
-		startService(svc, false)
+		systemctlStart(svc)
 	}
 
 	return nil


### PR DESCRIPTION
simplify the service restart logic by relying on relevant systemctl commands

* start ssh if not started at the end of non-oslogin account setup 
* reload-or-restart ssh at the end of oslogin setup
* use try-restart on additional services rather than calling is-active && restart