### PR TITLE
use systemd-notify in agentInit

### DIFF
--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -13,7 +13,7 @@ Wants=network-online.target
 PartOf=network.service networking.service NetworkManager.service systemd-networkd.service
 
 [Service]
-Type=simple
+Type=notify
 ExecStart=/usr/bin/google_guest_agent
 OOMScoreAdjust=-999
 Restart=always

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -104,6 +104,7 @@ func agentInit(ctx context.Context) {
 		}
 	} else {
 		// Linux instance setup.
+		defer runCmd(exec.Command("systemd-notify", "--ready"))
 
 		if config.Section("Snapshots").Key("enabled").MustBool(false) {
 			logger.Infof("Snapshot listener enabled")


### PR DESCRIPTION
this changes the systemd service type from `simple` to `notify` , and emits the READY=1 signal in the agentInit function. This means units which start `after` the guest agent won't be started until this signal is emitted, fixing startup race conditions related to SSH hostkey generation