### PR TITLE
use IP for MDS

### DIFF
--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -130,8 +130,6 @@ func run(ctx context.Context) {
 		opts.Writers = []io.Writer{&serialPort{"COM1"}}
 	}
 
-	setMetadataURL()
-
 	var err error
 	newMetadata, err = getMetadata(ctx, false)
 	if err == nil {
@@ -173,9 +171,6 @@ func run(ctx context.Context) {
 				// not to spam the log on network failures.
 				if webError == 1 {
 					if urlErr, ok := err.(*url.Error); ok {
-						if _, ok := urlErr.Err.(*net.DNSError); ok {
-							logger.Errorf("DNS error when requesting metadata, check DNS settings and ensure metadata.internal.google is setup in your hosts file.")
-						}
 						if _, ok := urlErr.Err.(*net.OpError); ok {
 							logger.Errorf("Network error when requesting metadata, make sure your instance has an active network and can reach the metadata server.")
 						}

--- a/google_guest_agent/metadata.go
+++ b/google_guest_agent/metadata.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -32,23 +31,12 @@ import (
 const defaultEtag = "NONE"
 
 var (
-	metadataURL       = ""
-	metadataHost      = "metadata.google.internal"
-	metadataFallback  = "169.254.169.254"
-	metadataPath      = "/computeMetadata/v1/"
+	metadataURL       = "http://169.254.169.254/computeMetadata/v1/"
 	metadataRecursive = "/?recursive=true&alt=json"
 	metadataHang      = "&wait_for_change=true&timeout_sec=60"
 	defaultTimeout    = 70 * time.Second
 	etag              = defaultEtag
 )
-
-func setMetadataURL() {
-	host := metadataHost
-	if _, err := net.LookupIP(host); err != nil {
-		host = metadataFallback
-	}
-	metadataURL = "http://" + host + metadataPath
-}
 
 type metadata struct {
 	Instance instance


### PR DESCRIPTION
using name was originally intended to future proof against IP changes - but the security vulnerability it introduces outweighs that.