### PR TITLE
support enable-oslogin-sk key

### DIFF
--- a/google_guest_agent/metadata.go
+++ b/google_guest_agent/metadata.go
@@ -107,6 +107,7 @@ type attributes struct {
 	BlockProjectKeys      bool
 	EnableOSLogin         *bool
 	TwoFactor             *bool
+	SecurityKey           *bool
 	SSHKeys               []string
 	WindowsKeys           windowsKeys
 	Diagnostics           string
@@ -170,6 +171,7 @@ func (a *attributes) UnmarshalJSON(b []byte) error {
 		OldSSHKeys            string      `json:"sshKeys"`
 		SSHKeys               string      `json:"ssh-keys"`
 		TwoFactor             string      `json:"enable-oslogin-2fa"`
+		SecurityKey           string      `json:"enable-oslogin-sk"`
 		WindowsKeys           windowsKeys `json:"windows-keys"`
 		WSFCAddresses         string      `json:"wsfc-addrs"`
 		WSFCAgentPort         string      `json:"wsfc-agent-port"`
@@ -210,6 +212,10 @@ func (a *attributes) UnmarshalJSON(b []byte) error {
 	value, err = strconv.ParseBool(temp.TwoFactor)
 	if err == nil {
 		a.TwoFactor = mkbool(value)
+	}
+	value, err = strconv.ParseBool(temp.SecurityKey)
+	if err == nil {
+		a.SecurityKey = mkbool(value)
 	}
 	// So SSHKeys will be nil instead of []string{}
 	if temp.SSHKeys != "" {

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -78,8 +78,8 @@ func (a *accountsMgr) diff() bool {
 		}
 	}
 	// If we've just disabled OS Login.
-	oldOslogin, _ := getOSLoginEnabled(oldMetadata)
-	newOslogin, _ := getOSLoginEnabled(newMetadata)
+	oldOslogin, _, _ := getOSLoginEnabled(oldMetadata)
+	newOslogin, _, _ := getOSLoginEnabled(newMetadata)
 	if oldOslogin && !newOslogin {
 		return true
 	}
@@ -92,7 +92,7 @@ func (a *accountsMgr) timeout() bool {
 }
 
 func (a *accountsMgr) disabled(os string) bool {
-	oslogin, _ := getOSLoginEnabled(newMetadata)
+	oslogin, _, _ := getOSLoginEnabled(newMetadata)
 	return false ||
 		os == "windows" || oslogin ||
 		!config.Section("Daemons").Key("accounts_daemon").MustBool(true)


### PR DESCRIPTION
support new md key `enable-oslogin-sk`, which follows the paradigm of `enable-oslogin-2fa`.
this key changes the `AuthorizedKeysCommand` directive in /etc/ssh/sshd_config