### PR TITLE
forbid root user from metadata

### DIFF
--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -122,7 +122,7 @@ func (a *accountsMgr) set() error {
 			continue
 		}
 		user := key[:idx]
-		if user == "" {
+		if user == "" || user == "root" {
 			continue
 		}
 		userKeys := mdKeyMap[user]


### PR DESCRIPTION
this was an oversight and was never intended to be supported. in images built by Google, the VM image will anyway not permit root logins of any kind.