### PR TITLE
correct linux startup script order

### DIFF
--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -351,19 +351,17 @@ func getWantedKeys(args []string, os string) ([]string, error) {
 	}
 
 	var mdkeys []string
-	suffixes := []string{"url"}
+	var suffixes []string
 	if os == "windows" {
-		// This ordering matters. URL is last on Windows, first otherwise.
 		suffixes = []string{"ps1", "cmd", "bat", "url"}
+	} else {
+		suffixes = []string{"url"}
+		// The 'bare' startup-script or shutdown-script key, not supported on Windows.
+		mdkeys = append(mdkeys, fmt.Sprintf("%s-script", prefix))
 	}
 
 	for _, suffix := range suffixes {
 		mdkeys = append(mdkeys, fmt.Sprintf("%s-script-%s", prefix, suffix))
-	}
-
-	// The 'bare' startup-script or shutdown-script key, not supported on Windows.
-	if os != "windows" {
-		mdkeys = append(mdkeys, fmt.Sprintf("%s-script", prefix))
 	}
 
 	return mdkeys, nil

--- a/google_metadata_script_runner/main_test.go
+++ b/google_metadata_script_runner/main_test.go
@@ -68,16 +68,16 @@ func TestGetWantedArgs(t *testing.T) {
 			"startup",
 			"linux",
 			[]string{
-				"startup-script-url",
 				"startup-script",
+				"startup-script-url",
 			},
 		},
 		{
 			"shutdown",
 			"linux",
 			[]string{
-				"shutdown-script-url",
 				"shutdown-script",
+				"shutdown-script-url",
 			},
 		},
 	}


### PR DESCRIPTION
Update to match documentation and enable -url scripts to run after bare scripts (useful for our testing)

For [Windows](https://cloud.google.com/compute/docs/instances/startup-scripts/windows#order_of_execution_of_windows_startup_scripts)
```
windows-startup-script-ps1	First during each boot after the initial boot
windows-startup-script-cmd	Second during each boot after the initial boot
windows-startup-script-bat	Third during each boot after the initial boot
windows-startup-script-url	Fourth during each boot after the initial boot
```

For [Linux](https://cloud.google.com/compute/docs/instances/startup-scripts/linux#order_of_execution_of_linux_startup_scripts)
```
startup-script		First during each boot after the initial boot
startup-script-url	Second during each boot after the initial boot
```