### PR TITLE
Add WantedBy network dependencies to google-guest-agent service

### DIFF
--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -22,3 +22,4 @@ StandardOutput=journal+console
 [Install]
 WantedBy=sshd.service
 WantedBy=multi-user.target
+WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service


### PR DESCRIPTION
This will allow systemd to bring up google-guest-agent if one of the
networking services is brought up. Currently if a networking service
is stopped, google-guest-agent will be stopped and then won't come
up again when the networking service is started.

I tested on an ubuntu cloud instance running 'netplan apply' then checking google-guest-agent.service. Without this patch, it is inactive. With this patch, it shows as active. Stopping/killing the service had no effect on the networking services. I haven't tested that manually killing a network service still brings down google-guest-agent, but I'm not sure there's an easy way to do that over ssh.