### PR TITLE
dont open ssh tempfile exclusively

### DIFF
--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -486,7 +486,7 @@ func updateAuthorizedKeysFile(user string, keys []string) error {
 		userKeys = append(userKeys, key)
 	}
 
-	newfile, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	newfile, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
if the temporary file (/home/username/.ssh/authorized_keys.google) already exists, we would fail to open it here, and would never update ssh keys for username again. since we're the only actor likely to be creating such a file, it's reasonable to be a bit more aggressive and overwrite it if it exists.