### PR TITLE
enforce script ordering

### DIFF
--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -472,13 +472,17 @@ func main() {
 		return
 	}
 
-	for key, value := range scripts {
-		logger.Infof("Found %s in metadata.", key)
-		if err := runScript(ctx, key, value); err != nil {
-			logger.Infof("%s %s", key, err)
+	for _, wantedKey := range wantedKeys {
+		value, ok := scripts[wantedKey]
+		if !ok {
 			continue
 		}
-		logger.Infof("%s exit status 0", key)
+		logger.Infof("Found %s in metadata.", wantedKey)
+		if err := runScript(ctx, wantedKey, value); err != nil {
+			logger.Infof("%s %s", wantedKey, err)
+			continue
+		}
+		logger.Infof("%s exit status 0", wantedKey)
 	}
 
 	logger.Infof("Finished running %s scripts.", os.Args[1])


### PR DESCRIPTION
The map from `getExistingKeys` can't be used to guarantee script run ordering, as range over a map is not guaranteed to be ordered. Use the ordered `wantedKeys` slice from `getWantedKeys` to dictate the run order, instead.