### PR TITLE
handle comm errors in script runner

### DIFF
--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -319,13 +319,20 @@ func runCmd(c *exec.Cmd, name string) error {
 	pw.Close()
 
 	in := bufio.NewScanner(pr)
-	for in.Scan() {
+	for {
+		if !in.Scan() {
+			if err := in.Err(); err != nil {
+				logger.Errorf("error while communicating with %q script: %v", name, err)
+			}
+			break
+		}
 		logger.Log(logger.LogEntry{
 			Message:   fmt.Sprintf("%s: %s", name, in.Text()),
 			CallDepth: 3,
 			Severity:  logger.Info,
 		})
 	}
+	pr.Close()
 
 	return c.Wait()
 }


### PR DESCRIPTION
Without error checking, it's possible to leave the scanner loop with an open pipe, thus c.Wait() will hang indefinitely

* add error check during each scanner read
* explicitly close the pipe after scanning