### PR TITLE
A default umask of 0022 allows all users to read the contents of others home directories

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -276,13 +276,13 @@ func updatePAMsshd(pamsshd string, enable, twofactor bool) string {
 	authGroup := "auth       [default=ignore] pam_group.so"
 	accountOSLogin := "account    [success=ok ignore=ignore default=die] pam_oslogin_login.so"
 	accountOSLoginAdmin := "account    [success=ok default=ignore] pam_oslogin_admin.so"
-	sessionHomeDir := "session    [success=ok default=ignore] pam_mkhomedir.so"
+	sessionHomeDir := "session    [success=ok default=ignore] pam_mkhomedir.so umask=0077"
 
 	if runtime.GOOS == "freebsd" {
 		authOSLogin = "auth       optional pam_oslogin_login.so"
 		authGroup = "auth       optional pam_group.so"
 		accountOSLogin = "account    requisite pam_oslogin_login.so"
-		accountOSLoginAdmin = "account    optional pam_oslogin_admin.so"
+		accountOSLoginAdmin = "account    optional pam_oslogin_admin.so umask=0077"
 		sessionHomeDir = "session    optional pam_mkhomedir.so"
 	}
 


### PR DESCRIPTION
Without setting `umask=0077` user credentials, such as gcloud tokens*, can be exposed to everyone logging into a VM. A umask of 0077 will set home directories to be only readable to the user owns the home directory.

Using this agent on RHEL, Fedora or [Ubuntu from 21.04](https://www.phoronix.com/scan.php?page=news_item&px=Ubuntu-21.04-Private-Home) will revert security controls that users expect to be present.

*I mean tokens written out by gcloud logs, as they're set to DEBUG by default, which logs auth tokens as in API responses.