### PR TITLE
dont duplicate logs

### DIFF
--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -17,7 +17,6 @@ Type=notify
 ExecStart=/usr/bin/google_guest_agent
 OOMScoreAdjust=-999
 Restart=always
-StandardOutput=journal+console
 
 [Install]
 WantedBy=sshd.service

--- a/google-shutdown-scripts.service
+++ b/google-shutdown-scripts.service
@@ -11,7 +11,6 @@ RemainAfterExit=true
 ExecStop=/usr/bin/google_metadata_script_runner shutdown
 TimeoutStopSec=0
 KillMode=process
-StandardOutput=journal+console
 
 [Install]
 WantedBy=multi-user.target

--- a/google-startup-scripts.service
+++ b/google-startup-scripts.service
@@ -9,7 +9,6 @@ Type=oneshot
 ExecStart=/usr/bin/google_metadata_script_runner startup
 #TimeoutStartSec is ignored for Type=oneshot service units.
 KillMode=process
-StandardOutput=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change eliminates duplicated logging on the serial console for GCE VMs.

The default value for this directive is `journal`; adding +console strangely sends a duplicated line to what I know as kmsg, i.e. the messages available via dmesg and logged with the [0.0000 logmessage] format to the console.

Tested on all supported distros