### PR TITLE
List IPv6 routes

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -146,14 +146,16 @@ func getLocalRoutes(ifname string) ([]string, error) {
 			res = append(res, line)
 		}
 	}
-	// and again for IPv6 routes
-	args = fmt.Sprintf("-6 %s", args)
-	out := runCmdOutput(exec.Command("ip", strings.Split(args, " ")...))
+
+	// and again for IPv6 routes, without 'scope host' which is IPv4 only
+	args = fmt.Sprintf("-6 route list table local type local dev %s proto %s", ifname, protoID)
+	out = runCmdOutput(exec.Command("ip", strings.Split(args, " ")...))
 	if out.ExitCode() != 0 {
 		return nil, error(out)
 	}
 	for _, line := range strings.Split(out.Stdout(), "\n") {
 		line = strings.TrimPrefix(line, "local ")
+		line = strings.Split(line, " ")[0]
 		line = strings.TrimSpace(line)
 		if line != "" {
 			res = append(res, line)

--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -146,6 +146,19 @@ func getLocalRoutes(ifname string) ([]string, error) {
 			res = append(res, line)
 		}
 	}
+	// and again for IPv6 routes
+	args = fmt.Sprintf("-6 %s", args)
+	out := runCmdOutput(exec.Command("ip", strings.Split(args, " ")...))
+	if out.ExitCode() != 0 {
+		return nil, error(out)
+	}
+	for _, line := range strings.Split(out.Stdout(), "\n") {
+		line = strings.TrimPrefix(line, "local ")
+		line = strings.TrimSpace(line)
+		if line != "" {
+			res = append(res, line)
+		}
+	}
 	return res, nil
 }
 


### PR DESCRIPTION
Update `ip route list` command to return IPv6 routes

tested working:
```
DEBUG addresses.go:317 Add routes for aliases, forwarded IP and target-instance IPs
DEBUG main.go:248 exec: /usr/sbin/ip route list table local type local scope host dev enp0s4 proto 66
DEBUG main.go:248 exec: /usr/sbin/ip -6 route list table local type local dev enp0s4 proto 66
DEBUG addresses.go:365: Got local routes: []
Changing forwarded IPs for 42:01:0a:01:00:0a from [] to ["2600:1901:ffb0:394e:8000::/96"] by adding ["2600:1901:ffb0:394e:8000::/96"]
DEBUG main.go:248 exec: /usr/sbin/ip route add to local 2600:1901:ffb0:394e:8000::/96 scope host dev enp0s4 proto 66
```

and restart agent, confirm it identifies routes already exist:
```
DEBUG addresses.go:317 Add routes for aliases, forwarded IP and target-instance IPs
DEBUG main.go:248 exec: /usr/sbin/ip route list table local type local scope host dev enp0s4 proto 66
DEBUG main.go:248 exec: /usr/sbin/ip -6 route list table local type local dev enp0s4 proto 66
DEBUG: addresses.go:365 Got local routes: [2600:1901:ffb0:394e:8000::/96]
```

Notice it thinks no change is necessary at the end.