### PR TITLE
Allow disabling parts of the agent that imperatively configure the system

### DIFF
--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -104,13 +104,15 @@ func (a *accountsMgr) set() error {
 		sshKeys = make(map[string][]string)
 	}
 
-	logger.Debugf("create sudoers file if needed")
-	if err := createSudoersFile(); err != nil {
-		logger.Errorf("Error creating google-sudoers file: %v.", err)
-	}
-	logger.Debugf("create sudoers group if needed")
-	if err := createSudoersGroup(); err != nil {
-		logger.Errorf("Error creating google-sudoers group: %v.", err)
+        if config.Section("Accounts").Key("setup").MustBool(true) {
+		logger.Debugf("create sudoers file if needed")
+		if err := createSudoersFile(); err != nil {
+			logger.Errorf("Error creating google-sudoers file: %v.", err)
+		}
+		logger.Debugf("create sudoers group if needed")
+		if err := createSudoersGroup(); err != nil {
+			logger.Errorf("Error creating google-sudoers group: %v.", err)
+		}
 	}
 
 	mdkeys := newMetadata.Instance.Attributes.SSHKeys

--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -76,7 +76,8 @@ func (o *osloginMgr) timeout() bool {
 }
 
 func (o *osloginMgr) disabled(os string) bool {
-	return os == "windows"
+	return os == "windows" ||
+		!config.Section("Daemons").Key("oslogin_daemon").MustBool(true)
 }
 
 func (o *osloginMgr) set() error {


### PR DESCRIPTION
On NixOS we configure the whole system via our declarative configuration system. `/etc` is mostly immutable, so Guest Agent produces several error messages. These patches allow to (optionally) disable parts of Guest Agent that conflict with our configuration.