### PR TITLE
enable goproxy during build

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -7,6 +7,7 @@ export DH_OPTIONS
 export DH_GOPKG := github.com/GoogleCloudPlatform/guest-agent
 export CGO_ENABLED := 0
 export GOCACHE := /tmp/.cache
+export GOPROXY := https://proxy.golang.org
 export GO111MODULE := on
 
 %:


### PR DESCRIPTION
Debian 11's dh-golang has a default of `GOPROXY=off`; we still use downloads during builds, so this needs to be explicitly set. 