### PR TITLE
Support .exe as an option for scripts and refactor runScript

### DIFF
--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -239,21 +239,21 @@ func getMetadata(key string, recurse bool) ([]byte, error) {
 	return md, nil
 }
 
-func normalizeTmpFileForWindows(tmpFile string, metadataKey string, gcsScriptUrl *url.URL) string {
-	// If either the metadataKey ends in one of these extensions OR if this is a url startup script and if the 
+func normalizeTmpFileForWindows(tmpFile string, metadataKey string, gcsScriptURL *url.URL) string {
+	// If either the metadataKey ends in one of these extensions OR if this is a url startup script and if the
 	// url path ends in one of these extensions, append the extension to the tmpFile name so that Windows can recognize it.
 	for _, ext := range []string{"bat", "cmd", "ps1", "exe"} {
-		if strings.HasSuffix(metadataKey, "-"+ext) || (gcsScriptUrl != nil && strings.HasSuffix(gcsScriptUrl.Path, "."+ext)) {
+		if strings.HasSuffix(metadataKey, "-"+ext) || (gcsScriptURL != nil && strings.HasSuffix(gcsScriptURL.Path, "."+ext)) {
 			tmpFile = fmt.Sprintf("%s.%s", tmpFile, ext)
 			break
 		}
 	}
-	return tmpFile;
+	return tmpFile
 }
 
-func initScriptTmpFile(ctx context.Context, value string, tmpFile string, gcsScriptUrl *url.URL) error {
+func initScriptTmpFile(ctx context.Context, value string, tmpFile string, gcsScriptURL *url.URL) error {
 	// Create or download files.
-	if gcsScriptUrl != nil {
+	if gcsScriptURL != nil {
 		file, err := os.OpenFile(tmpFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 		if err != nil {
 			return fmt.Errorf("error opening temp file: %v", err)
@@ -278,10 +278,10 @@ func initScriptTmpFile(ctx context.Context, value string, tmpFile string, gcsScr
 
 func setupAndRunScript(ctx context.Context, metadataKey string, value string) error {
 	// Make sure that the URL is valid for URL startup scripts
-	var gcsScriptUrl *url.URL
+	var gcsScriptURL *url.URL
 	if strings.HasSuffix(metadataKey, "-url") {
 		var err error
-		gcsScriptUrl, err = url.Parse(strings.TrimSpace(value))
+		gcsScriptURL, err = url.Parse(strings.TrimSpace(value))
 		if err != nil {
 			return err
 		}
@@ -296,9 +296,9 @@ func setupAndRunScript(ctx context.Context, metadataKey string, value string) er
 
 	tmpFile := filepath.Join(tmpDir, metadataKey)
 	if runtime.GOOS == "windows" {
-		tmpFile = normalizeTmpFileForWindows(tmpFile, metadataKey, gcsScriptUrl)
+		tmpFile = normalizeTmpFileForWindows(tmpFile, metadataKey, gcsScriptURL)
 	}
-	initScriptTmpFile(ctx, value, tmpFile, gcsScriptUrl)
+	initScriptTmpFile(ctx, value, tmpFile, gcsScriptURL)
 
 	logger.Infof("Found %s in %s. Running now.", value, metadataKey)
 	return runScript(tmpFile, metadataKey)

--- a/google_metadata_script_runner/main_test.go
+++ b/google_metadata_script_runner/main_test.go
@@ -182,9 +182,9 @@ func TestNormalizeTmpFileForWindows(t *testing.T) {
 	tmpFilePath := "C:/Temp/file"
 
 	testCases := []struct {
-		metadataKey string
-		gcsScriptUrlPath string
-		want string
+		metadataKey      string
+		gcsScriptURLPath string
+		want             string
 	}{
 		{
 			"windows-startup-script-url",
@@ -219,14 +219,14 @@ func TestNormalizeTmpFileForWindows(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		url := url.URL {
-			Path: tc.gcsScriptUrlPath,
+		url := url.URL{
+			Path: tc.gcsScriptURLPath,
 		}
 		got := normalizeTmpFileForWindows(tmpFilePath, tc.metadataKey, &url)
 
 		if got != tc.want {
 			t.Errorf("Return didn't match expected output for inputs:\n fileName: %s, metadataKey: %s, gcsScriptUrl: %s\n Expected: %s\n Got: %s",
-			tmpFilePath, tc.metadataKey, tc.gcsScriptUrlPath, tc.want, got)
+				tmpFilePath, tc.metadataKey, tc.gcsScriptURLPath, tc.want, got)
 		}
 	}
 }

--- a/google_metadata_script_runner/main_test.go
+++ b/google_metadata_script_runner/main_test.go
@@ -187,34 +187,34 @@ func TestNormalizeFilePathForWindows(t *testing.T) {
 		want             string
 	}{
 		{
-			"windows-startup-script-url",
-			"gs://gcs-bucket/binary.exe",
-			"C:/Temp/file.exe",
+			metadataKey:      "windows-startup-script-url",
+			gcsScriptURLPath: "gs://gcs-bucket/binary.exe",
+			want:             "C:/Temp/file.exe",
 		},
 		{
-			"windows-startup-script-url",
-			"gs://gcs-bucket/binary",
-			"C:/Temp/file",
+			metadataKey:      "windows-startup-script-url",
+			gcsScriptURLPath: "gs://gcs-bucket/binary",
+			want:             "C:/Temp/file",
 		},
 		{
-			"windows-startup-script-ps1",
-			"gs://gcs-bucket/binary.ps1",
-			"C:/Temp/file.ps1",
+			metadataKey:      "windows-startup-script-ps1",
+			gcsScriptURLPath: "gs://gcs-bucket/binary.ps1",
+			want:             "C:/Temp/file.ps1",
 		},
 		{
-			"windows-startup-script-ps1",
-			"gs://gcs-bucket/binary",
-			"C:/Temp/file.ps1",
+			metadataKey:      "windows-startup-script-ps1",
+			gcsScriptURLPath: "gs://gcs-bucket/binary",
+			want:             "C:/Temp/file.ps1",
 		},
 		{
-			"windows-startup-script-bat",
-			"gs://gcs-bucket/binary.bat",
-			"C:/Temp/file.bat",
+			metadataKey:      "windows-startup-script-bat",
+			gcsScriptURLPath: "gs://gcs-bucket/binary.bat",
+			want:             "C:/Temp/file.bat",
 		},
 		{
-			"windows-startup-script-cmd",
-			"gs://gcs-bucket/binary.cmd",
-			"C:/Temp/file.cmd",
+			metadataKey:      "windows-startup-script-cmd",
+			gcsScriptURLPath: "gs://gcs-bucket/binary.cmd",
+			want:             "C:/Temp/file.cmd",
 		},
 	}
 

--- a/google_metadata_script_runner/main_test.go
+++ b/google_metadata_script_runner/main_test.go
@@ -178,7 +178,7 @@ func TestGetMetadata(t *testing.T) {
 	}
 }
 
-func TestNormalizeTmpFileForWindows(t *testing.T) {
+func TestNormalizeFilePathForWindows(t *testing.T) {
 	tmpFilePath := "C:/Temp/file"
 
 	testCases := []struct {
@@ -222,7 +222,7 @@ func TestNormalizeTmpFileForWindows(t *testing.T) {
 		url := url.URL{
 			Path: tc.gcsScriptURLPath,
 		}
-		got := normalizeTmpFileForWindows(tmpFilePath, tc.metadataKey, &url)
+		got := normalizeFilePathForWindows(tmpFilePath, tc.metadataKey, &url)
 
 		if got != tc.want {
 			t.Errorf("Return didn't match expected output for inputs:\n fileName: %s, metadataKey: %s, gcsScriptUrl: %s\n Expected: %s\n Got: %s",


### PR DESCRIPTION
Adds support for windows binaries as part of the startup script.

Also refactors and adds some unit tests to make the code easier to understand.