### PR TITLE
restore double slash metadata url

### DIFF
--- a/google_guest_agent/metadata.go
+++ b/google_guest_agent/metadata.go
@@ -32,7 +32,7 @@ import (
 const defaultEtag = "NONE"
 
 var (
-	metadataURL       = "http://169.254.169.254/computeMetadata/v1"
+	metadataURL       = "http://169.254.169.254/computeMetadata/v1/"
 	metadataRecursive = "/?recursive=true&alt=json"
 	metadataHang      = "&wait_for_change=true&timeout_sec=60"
 	defaultTimeout    = 70 * time.Second


### PR DESCRIPTION
rollback #151 as it induced test failures