### PR TITLE
no authorized keys on debian

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,6 +24,7 @@ override_dh_golang:
 
 override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
+	rm obj-x86_64-linux-gnu/bin/google_authorized_keys
 
 override_dh_installinit:
 	# We don't ship sysvinit files or need script changes for them.


### PR DESCRIPTION
debian's build system autodetects and includes binaries; we aren't ready to ship this binary on linux, yet.