### PR TITLE
Remove log that can break daisy workflows using WaitForInstancesSignal

### DIFF
--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -300,7 +300,6 @@ func setupAndRunScript(ctx context.Context, metadataKey string, value string) er
 	}
 	writeScriptToFile(ctx, value, tmpFile, gcsScriptURL)
 
-	logger.Infof("Found %s in %s. Running now.", value, metadataKey)
 	return runScript(tmpFile, metadataKey)
 }
 


### PR DESCRIPTION
When running Daisy workflows with a `WaitForInstancesSignal` step it's possible for the SuccessMatch to be unintentionally triggered if the full script gets logged. 

For example this is causing startup scripts (e.g. [bare-metal](https://github.com/GoogleCloudPlatform/compute-image-tools/blob/master/daisy_workflows/image_build/bare_metal/bare_metal_image_preparer.sh)) to be cut short since Daisy will detect `BuildSuccess` in the serial output (when the file gets logged). The startup-script is added to metadata and will get logged by this line.

This PR is removing the log for now to unblock Daisy workflows. Will explore how to properly log this data going forward. 