### PR TITLE
packaging/rpm: add explicit dependency on `/usr/bin/cp`

### DIFF
--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -25,6 +25,7 @@ Url: https://cloud.google.com/compute/docs/images/guest-environment
 Source0: %{name}_%{version}.orig.tar.gz
 
 BuildArch: %{_arch}
+Requires(post): /usr/bin/cp
 %if ! 0%{?el6}
 BuildRequires: systemd
 %endif


### PR DESCRIPTION
The `google-guest-agent.spec` relies on the `cp` tool for copying of
files in the `%post` scriptlet, however it does not explicitly depend on
it.

This does not create any issues in common situations when installing
the package on existing system or when building images using
Anaconda and installing the package in the kickstart post section,
because the binary is already installed.

However this results in a scriptlet failure when installing the package
into an empty root with all of its recursive dependencies:
```
google-guest-agent-1:20211116.00-g1.el8.x86_64
/var/tmp/rpm-tmp.QXxYSR: line 6: cp: command not found
```

The latest tooling (osbuild-composer [1])  used by Red Hat to build
RHEL images, including those for GCP, runs into this issue because of
the way it depsolves transaction and installs packages into the image.

In `osbuild-composer`, we do:
1. Take the base package set, which for GCE image includes the GCP
   SDK as well as guest environment packages.
2. Pass the base package set to DNF API for dependency solving as
   if there was nothing installed on the system. The result is a
   list of packages to be installed in the image, which are installed
   in exactly the same order as returned by DNF.
3. Take the result of the dependency solving and install it using `rpm
   --root <image_fs_root> --install <packages...>.

The issue that we are running into is that DNF orders packages in the
transaction in a way, that `coreutils`, which ship `cp` is installed
after the `google-guest-agent` package. From DNF point of view, this is
OK, because the `google-guest-agent` does not specify any dependency on
the `coreutils` package.

Modify the SPEC file to include Requires for the `/usr/bin/cp` binary
in the `%post` section.

[1] https://github.com/osbuild/osbuild-composer