### PR TITLE
write workload cert status file

### DIFF
--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -247,6 +247,11 @@ func refreshCreds() error {
 		return fmt.Errorf("Error getting workload-identities: %v", err)
 	}
 
+	certConfigStatus, err := getMetadata("instance/workload-certificates-config-status")
+	if err != nil {
+		return fmt.Errorf("Error getting config status: %v", err)
+	}
+
 	domain := fmt.Sprintf("%s.svc.id.goog", project)
 	logger.Infof("Rotating workload credentials for domain %s", domain)
 
@@ -268,6 +273,10 @@ func refreshCreds() error {
 
 	if err := os.MkdirAll(contentDir, 0755); err != nil {
 		return fmt.Errorf("Error creating contents dir: %v", err)
+	}
+
+	if err := os.WriteFile(fmt.Sprintf("%s/config_status", contentDir), certConfigStatus, 0644); err != nil {
+		return fmt.Errorf("Error writing config_status: %v", err)
 	}
 
 	if err := os.WriteFile(fmt.Sprintf("%s/certificates.pem", contentDir), []byte(wis.WorkloadCredentials[domain].CertificatePem), 0644); err != nil {

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// GoogleAuthorizedKeys obtains SSH keys from metadata.
+// gce_workload_cert_refresh downloads and rotates workload certificates for GCE VMs.
 package main
 
 import (
@@ -91,7 +91,7 @@ metadata key instance/workload-identities
 	{
 	 "status": "OK",
 	 "workloadCredentials": {
-	  "PROJECT.svc.id.goog": {
+	  "PROJECT_ID.svc.id.goog": {
 	   "metadata": {
 	    "workload_creds_dir_path": "/var/run/secrets/workload-spiffe-credentials"
 	   },
@@ -245,7 +245,7 @@ func refreshCreds() error {
 	}
 
 	domain := fmt.Sprintf("%s.svc.id.goog", project)
-	logger.Infof("Rotating workload credentials for domain %s", domain)
+	logger.Infof("Rotating workload credentials for trust domain %s", domain)
 
 	now := time.Now().Format(time.RFC3339)
 	contentDir := fmt.Sprintf("%s-%s", contentDirPrefix, now)


### PR DESCRIPTION
Add config_status file for user troubleshooting.

```
$ sudo ./gce_workload_cert_refresh 
2022/10/18 18:28:33: Rotating workload credentials for domain [REDACT].svc.id.goog
2022/10/18 18:28:33: Creating timestamp contents dir /run/secrets/workload-spiffe-contents-2022-10-18T18:28:33Z
2022/10/18 18:28:33: Rotating symlink /run/secrets/workload-spiffe-credentials
2022/10/18 18:28:33: Remove old content dir /run/secrets/workload-spiffe-contents-2022-10-18T18:20:13Z
2022/10/18 18:28:33: Done

$ ls /run/secrets/workload-spiffe-credentials
ca_certificates.pem  certificates.pem  config_status  private_key.pem

$ cat /run/secrets/workload-spiffe-credentials/config_status
{
 "status": "OK",
 "metadataAttributesErrors": {}
}
```