### PR TITLE
Updates to gce-workload-cert-refresh

### DIFF
--- a/gce-workload-cert-refresh.timer
+++ b/gce-workload-cert-refresh.timer
@@ -3,7 +3,7 @@ Description=GCE Workload Certificate refresh timer
 
 [Timer]
 OnBootSec=5
-OnUnitActiveSec=30m
+OnUnitActiveSec=10m
 
 [Install]
 WantedBy=timers.target

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -77,6 +77,10 @@ func getMetadata(key string) ([]byte, error) {
 		return nil, fmt.Errorf("HTTP 404")
 	}
 
+	if res.StatusCode == 412 {
+		return nil, fmt.Errorf("HTTP 412")
+	}
+
 	defer res.Body.Close()
 	md, err := ioutil.ReadAll(res.Body)
 	if err != nil {
@@ -266,7 +270,7 @@ func refreshCreds() error {
 	// that the symlink directory exists and contains the config_status to surface config errors to the VM.
 	defer func() error {
 		if _, err := os.Stat(symlink); os.IsNotExist(err) {
-			logger.Infof("Creating symlink %s", symlink)
+			logger.Infof("Creating new symlink %s", symlink)
 
 			if err := os.Symlink(contentDir, symlink); err != nil {
 				return fmt.Errorf("Error creating symlink link: %v", err)
@@ -288,7 +292,7 @@ func refreshCreds() error {
 
 	wis := WorkloadIdentities{}
 	if err := json.Unmarshal(wisMd, &wis); err != nil {
-		return fmt.Errorf("Error unmarshaling workload trusted root certs: %v", err)
+		return fmt.Errorf("Error unmarshaling workload identities response: %v", err)
 	}
 
 	wtrcs := WorkloadTrustedRootCerts{}

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	contentDirPrefix  = "/run/secrets/.workload-spiffe-contents"
+	contentDirPrefix  = "/run/secrets/workload-spiffe-contents"
 	tempSymlinkPrefix = "/run/secrets/workload-spiffe-symlink"
 	symlink           = "/run/secrets/workload-spiffe-credentials"
 )
@@ -276,10 +276,6 @@ func refreshCreds() error {
 		if err := os.Symlink(contentDir, symlink); err != nil {
 			return fmt.Errorf("Error creating symlink: %v", err)
 		}
-		// Write config_status to the newly created symlink immediately.
-		if err := os.WriteFile(fmt.Sprintf("%s/config_status", contentDir), certConfigStatus, 0644); err != nil {
-			return fmt.Errorf("Error writing config_status to contents dir: %v", err)
-		}	
 	}
 
 	// Now get the rest of the content.

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -275,7 +275,6 @@ func refreshCreds() error {
 		return nil
 	}()
 
-
 	// Now get the rest of the content.
 	wisMd, err := getMetadata("instance/workload-identities")
 	if err != nil {

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -331,9 +331,10 @@ func refreshCreds() error {
 	// Clean up previous contents dir.
 	newTarget, err := os.Readlink(symlink)
 	if err != nil {
-		logger.Infof("Error reading new symlink: %v. Unable to remove old symlink target\n", err)
-	} else if oldTarget != "" && oldTarget != newTarget {
-		logger.Infof("Remove old content dir %s", oldTarget)
+		return fmt.Errorf("Error reading new symlink: %v. Unable to remove old symlink target\n", err)
+	}
+	if oldTarget != newTarget {
+		logger.Infof("Removing old content dir %s", oldTarget)
 		if err := os.RemoveAll(oldTarget); err != nil {
 			return fmt.Errorf("Failed to remove old symlink target: %v", err)
 		}

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -283,7 +283,7 @@ func refreshCreds() error {
 		if err := os.Symlink(contentDir, symlink); err != nil {
 			return fmt.Errorf("Error creating symlink link: %v", err)
 		}
-		// Write config_status to the new the newly created symlink immediately.
+		// Write config_status to the newly created symlink immediately.
 		if err := os.WriteFile(fmt.Sprintf("%s/config_status", symlink), certConfigStatus, 0644); err != nil {
 			return fmt.Errorf("Error writing config_status to existing symlink: %v", err)
 		}	

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -276,6 +276,12 @@ func refreshCreds() error {
 				return fmt.Errorf("Error creating symlink link: %v", err)
 			}
 		}
+		// Write config status to the current symlink dir in case we don't change the symlink to the new contentDir
+		// because of more config errors. E.g., a user can provide wrong config values multiple times. This requires
+		// we update the config_status without rotating the symlink because it may contain valid credentials.
+		if err := os.WriteFile(fmt.Sprintf("%s/config_status", symlink), certConfigStatus, 0644); err != nil {
+			return fmt.Errorf("Error writing config_status to existing symlink: %v", err)
+		}
 		return nil
 	}()
 

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -229,7 +229,7 @@ func main() {
 	// TODO: prune old dirs
 
 	if err := refreshCreds(); err != nil {
-		logger.Fatalf(err.Error())
+		logger.Fatalf("Error refreshCreds: %v", err.Error())
 	}
 
 }

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -328,16 +328,15 @@ func refreshCreds() error {
 		return fmt.Errorf("Error rotating target link: %v", err)
 	}
 
+	// Clean up previous contents dir.
 	newTarget, err := os.Readlink(symlink)
-	if err == nil {
-		if oldTarget != "" && oldTarget != newTarget {
-			logger.Infof("Remove old content dir %s", oldTarget)
-			if err := os.RemoveAll(oldTarget); err != nil {
-				return fmt.Errorf("Failed to remove old symlink target: %v", err)
-			}
-		}
-	} else {
+	if err != nil {
 		logger.Infof("Error reading new symlink: %v. Unable to remove old symlink target\n", err)
+	} else if oldTarget != "" && oldTarget != newTarget {
+		logger.Infof("Remove old content dir %s", oldTarget)
+		if err := os.RemoveAll(oldTarget); err != nil {
+			return fmt.Errorf("Failed to remove old symlink target: %v", err)
+		}
 	}
 
 	return nil

--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -331,7 +331,7 @@ func refreshCreds() error {
 	// Clean up previous contents dir.
 	newTarget, err := os.Readlink(symlink)
 	if err != nil {
-		return fmt.Errorf("Error reading new symlink: %v. Unable to remove old symlink target\n", err)
+		return fmt.Errorf("Error reading new symlink: %v, unable to remove old symlink target", err)
 	}
 	if oldTarget != newTarget {
 		logger.Infof("Removing old content dir %s", oldTarget)


### PR DESCRIPTION
This PR makes the following changes:

* Updates the gce-workload-cert-refresh.timer to run every 10mins.
* Explicitly handles HTTP 412 error while fetching data from MDS. This happens when no valid config was ever provided by the user.
* Handles the edge case where the config provided the very first time are wrong and needs to be communicated to VM via config_status.
* Adds logic to update the config_status in the existing symlink dir to surface latest config errors without rotating the symlink.
* Updates error messages.