### PR TITLE
Validate user key for whitespace chars

### DIFF
--- a/utils/main.go
+++ b/utils/main.go
@@ -93,9 +93,9 @@ func CheckExpired(expireOn string) (bool, error) {
 // allowed in a username string, returns an error if any such characters are
 // detected, nil otherwise.
 // Currently, the only banned characters are whitespace characters.
-func ValidateUserKey(user string) (error) {
+func ValidateUserKey(user string) error {
 	whiteSpaceRegexp, _ := regexp.Compile("\\s")
-	
+
 	hasWhiteSpace := whiteSpaceRegexp.MatchString(user)
 	if hasWhiteSpace {
 		return errors.New("Invalid username - whitespace detected")

--- a/utils/main.go
+++ b/utils/main.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"encoding/json"
 	"errors"
+	"regexp"
 	"strings"
 	"time"
 
@@ -88,6 +89,20 @@ func CheckExpired(expireOn string) (bool, error) {
 
 }
 
+// ValidateUserKey checks for the presence of a characters which should not be
+// allowed in a username string, returns an error if any such characters are
+// detected, nil otherwise.
+// Currently, the only banned characters are whitespace characters.
+func ValidateUserKey(user string) (error) {
+	whiteSpaceRegexp, _ := regexp.Compile("\\s")
+	
+	hasWhiteSpace := whiteSpaceRegexp.MatchString(user)
+	if hasWhiteSpace {
+		return errors.New("Invalid username - whitespace detected")
+	}
+	return nil
+}
+
 // GetUserKey takes a string and determines if it is a valid SSH key and returns
 // the user and key if valid, nil otherwise.
 func GetUserKey(rawKey string) (string, string, error) {
@@ -102,6 +117,9 @@ func GetUserKey(rawKey string) (string, string, error) {
 	user := key[:idx]
 	if user == "" {
 		return "", "", errors.New("Invalid ssh key entry - user missing")
+	}
+	if err := ValidateUserKey(user); err != nil {
+		return "", "", err
 	}
 	if err := CheckExpiredKey(key[idx+1:]); err != nil {
 		return "", "", err

--- a/utils/main.go
+++ b/utils/main.go
@@ -96,8 +96,7 @@ func CheckExpired(expireOn string) (bool, error) {
 func ValidateUserKey(user string) error {
 	whiteSpaceRegexp, _ := regexp.Compile("\\s")
 
-	hasWhiteSpace := whiteSpaceRegexp.MatchString(user)
-	if hasWhiteSpace {
+	if hasWhiteSpace := whiteSpaceRegexp.MatchString(user); hasWhiteSpace == true {
 		return errors.New("Invalid username - whitespace detected")
 	}
 	return nil

--- a/utils/main.go
+++ b/utils/main.go
@@ -96,7 +96,7 @@ func CheckExpired(expireOn string) (bool, error) {
 func ValidateUserKey(user string) error {
 	whiteSpaceRegexp, _ := regexp.Compile("\\s")
 
-	if hasWhiteSpace := whiteSpaceRegexp.MatchString(user); hasWhiteSpace == true {
+	if whiteSpaceRegexp.MatchString(user) {
 		return errors.New("Invalid username - whitespace detected")
 	}
 	return nil

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -101,7 +101,7 @@ func TestValidateUserKey(t *testing.T) {
 		err := ValidateUserKey(tt.user)
 		isValid := err == nil
 		if isValid != tt.valid {
-			t.Errorf("ValidateUserKey(%s) incorrect return: valid: %t - want valid: %t", tt.user, isValid, tt.valid)
+			t.Errorf("Invalid ValidateUserKey(%s) return: expected: %t - got: %t", tt.user, isValid, tt.valid)
 		}
 	}
 }

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -99,7 +99,7 @@ func TestValidateUserKey(t *testing.T) {
 	}
 	for _, tt := range table {
 		err := ValidateUserKey(tt.user)
-		isValid = err != nil
+		isValid := err != nil
 		if isValid != tt.valid {
 			t.Errorf("ValidateUserKey(%s) incorrect return: valid: %t - want valid: %t", tt.user, isValid, tt.valid)
 		}

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -83,3 +83,25 @@ func TestCheckExpiredKey(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateUserKey(t *testing.T) {
+	table := []struct {
+		user 	string
+		valid 	bool
+	}{
+		{"username", true},
+		{"username:key", true},
+		{"user -g", false},
+		{"user -g 27", false},
+		{"user\t-g", false},
+		{"user\n-g", false},
+		{"username\t-g\n27", false},
+	}
+	for _, tt := range table {
+		err := ValidateUserKey(tt.user)
+		isValid = err != nil
+		if isValid != tt.valid {
+			t.Errorf("ValidateUserKey(%s) incorrect return: valid: %t - want valid: %t", tt.user, isValid, tt.valid)
+		}
+	}
+}

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -99,7 +99,7 @@ func TestValidateUserKey(t *testing.T) {
 	}
 	for _, tt := range table {
 		err := ValidateUserKey(tt.user)
-		isValid := err != nil
+		isValid := err == nil
 		if isValid != tt.valid {
 			t.Errorf("ValidateUserKey(%s) incorrect return: valid: %t - want valid: %t", tt.user, isValid, tt.valid)
 		}

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -86,8 +86,8 @@ func TestCheckExpiredKey(t *testing.T) {
 
 func TestValidateUserKey(t *testing.T) {
 	table := []struct {
-		user 	string
-		valid 	bool
+		user  string
+		valid bool
 	}{
 		{"username", true},
 		{"username:key", true},


### PR DESCRIPTION
Add validation and testing for whitespace in user string. If whitespace is detected in the user string, it should be considered an invalid user string because it could be exploiting a security loophole. 