### PR TITLE
Fix typo with wsfc agent

### DIFF
--- a/google_guest_agent/wsfc.go
+++ b/google_guest_agent/wsfc.go
@@ -185,7 +185,7 @@ func (a *wsfcAgent) run() error {
 		}
 	}()
 
-	logger.Infof("wsfc agent stared. Listening on port: %s", a.port)
+	logger.Infof("wsfc agent started. Listening on port: %s", a.port)
 	a.listener = listener
 
 	return nil


### PR DESCRIPTION
It spells 'agent stared' where it should be 'agent started'.