### PR TITLE
use stricter regex for username validation

### DIFF
--- a/utils/main.go
+++ b/utils/main.go
@@ -94,10 +94,14 @@ func CheckExpired(expireOn string) (bool, error) {
 // detected, nil otherwise.
 // Currently, the only banned characters are whitespace characters.
 func ValidateUserKey(user string) error {
-	whiteSpaceRegexp, _ := regexp.Compile("\\s")
-
-	if whiteSpaceRegexp.MatchString(user) {
-		return errors.New("Invalid username - whitespace detected")
+	if len(user) > 32 {
+		return errors.New("Invalid username - exceeds maximum length")
+	}
+	// recommended linux username regex according to the manual
+	userRegexp, _ := regexp.Compile("[a-z_][a-z0-9_-]*[$]?")
+	
+	if userRegexp.FindString(user) != user {
+		return errors.New("Invalid username - detected an invalid character")
 	}
 	return nil
 }

--- a/utils/main.go
+++ b/utils/main.go
@@ -99,7 +99,7 @@ func ValidateUserKey(user string) error {
 	}
 	// recommended linux username regex according to the manual
 	userRegexp, _ := regexp.Compile("[a-z_][a-z0-9_-]*[$]?")
-	
+
 	if userRegexp.FindString(user) != user {
 		return errors.New("Invalid username - detected an invalid character")
 	}

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -101,7 +101,6 @@ func TestValidateUserKey(t *testing.T) {
 		{"badusername.23", false},
 		{"badusername/25\\", false},
 		{"baduser../#$@", false},
-		
 	}
 	for _, tt := range table {
 		err := ValidateUserKey(tt.user)

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -90,12 +90,18 @@ func TestValidateUserKey(t *testing.T) {
 		valid bool
 	}{
 		{"username", true},
-		{"username:key", true},
-		{"user -g", false},
-		{"user -g 27", false},
+		{"usernamekey", true},
+		{"user-g", true},
+		{"user g 27", false},
+		{"_underscore_user", true},
+		{"user_ending_in_dollar$", true},
 		{"user\t-g", false},
 		{"user\n-g", false},
 		{"username\t-g\n27", false},
+		{"badusername.23", false},
+		{"badusername/25\\", false},
+		{"baduser../#$@", false},
+		
 	}
 	for _, tt := range table {
 		err := ValidateUserKey(tt.user)


### PR DESCRIPTION
Due to other security threats, such as the possibility of path traversal attacks, this is a proposed change to ensure robustness of usernames from a variety of possible security threats. 