### PR TITLE
Windows: retry adding MDS route

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -31,6 +31,48 @@ import (
 	"github.com/go-ini/ini"
 )
 
+func getDefaultAdapter(fes []ipForwardEntry) (*ipForwardEntry, error) {
+	// Choose the first adapter index that has the default route setup.
+	// This is equivalent to how route.exe works when interface is not provided.
+	sort.Slice(fes, func(i, j int) bool { return fes[i].ipForwardIfIndex < fes[j].ipForwardIfIndex })
+	for _, fe := range fes {
+		if fe.ipForwardDest.Equal(net.ParseIP("0.0.0.0")) {
+			return &fe, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find default route")
+}
+
+func addMetadataRoute() error {
+	fes, err := getIPForwardEntries()
+	if err != nil {
+		return err
+	}
+
+	defaultRoute, err := getDefaultAdapter(fes)
+	if err != nil {
+		return err
+	}
+
+	forwardEntry := ipForwardEntry{
+		ipForwardDest:    net.ParseIP("169.254.169.254"),
+		ipForwardMask:    net.IPv4Mask(255, 255, 255, 255),
+		ipForwardNextHop: net.ParseIP("0.0.0.0"),
+		ipForwardMetric1: defaultRoute.ipForwardMetric1, // Must be <= the default route metric.
+		ipForwardIfIndex: defaultRoute.ipForwardIfIndex,
+	}
+
+	for _, fe := range fes {
+		if fe.ipForwardDest.Equal(forwardEntry.ipForwardDest) && fe.ipForwardIfIndex == forwardEntry.ipForwardIfIndex {
+			// No need to add entry, it's already setup.
+			return nil
+		}
+	}
+
+	logger.Infof("Adding route to metadata server on adapter with index %d", defaultRoute.ipForwardIfIndex)
+	return addIPForwardEntry(forwardEntry)
+}
+
 func agentInit(ctx context.Context) {
 	// Actions to take on agent startup.
 	//
@@ -49,57 +91,13 @@ func agentInit(ctx context.Context) {
 	// TODO incorporate these scripts into the agent. liamh@12-11-19
 
 	if runtime.GOOS == "windows" {
-		var index int32
-		var metric int32
-		var fes []ipForwardEntry
-		msg := "Could not set default route to metadata"
-	WaitLoop:
-		for {
-			fes, err := getIPForwardEntries()
-			if err != nil {
-				logger.Errorf("%s, error listing IPForwardEntries: %v", msg, err)
+		// Indefinitely retry to set up required MDS route.
+		for ; ; time.Sleep(1 * time.Second) {
+			if err := addMetadataRoute(); err != nil {
+				logger.Errorf("Could not set default route to metadata: %v", err)
+			} else {
+				break
 			}
-
-			// Choose the first adapter index that has the default route setup.
-			// This is equivalent to how route.exe works when interface is not provided.
-			sort.Slice(fes, func(i, j int) bool { return fes[i].ipForwardIfIndex < fes[j].ipForwardIfIndex })
-			for _, fe := range fes {
-				if fe.ipForwardDest.Equal(net.ParseIP("0.0.0.0")) {
-					index = fe.ipForwardIfIndex
-					metric = fe.ipForwardMetric1
-					break WaitLoop
-				}
-			}
-
-			logger.Errorf("%s, could not find the default route in IPForwardEntries: %+v", msg, fes)
-			time.Sleep(1 * time.Second)
-		}
-
-		iface, err := net.InterfaceByIndex(int(index))
-		if err != nil {
-			logger.Errorf("%s, error from net.InterfaceByIndex(%d): %v", msg, index, err)
-			return
-		}
-
-		forwardEntry := ipForwardEntry{
-			ipForwardDest:    net.ParseIP("169.254.169.254"),
-			ipForwardMask:    net.IPv4Mask(255, 255, 255, 255),
-			ipForwardNextHop: net.ParseIP("0.0.0.0"),
-			ipForwardMetric1: metric, // This needs to be at least equal to the default route metric.
-			ipForwardIfIndex: int32(iface.Index),
-		}
-
-		for _, fe := range fes {
-			if fe.ipForwardDest.Equal(forwardEntry.ipForwardDest) && fe.ipForwardIfIndex == forwardEntry.ipForwardIfIndex {
-				// No need to add entry, it's already setup.
-				return
-			}
-		}
-
-		logger.Infof("Adding route to metadata server on %q (index: %d)", iface.Name, iface.Index)
-		if err := addIPForwardEntry(forwardEntry); err != nil {
-			logger.Errorf("%s, error adding IPForwardEntry on %q (index: %d): %v", msg, iface.Name, iface.Index, err)
-			return
 		}
 	} else {
 		// Linux instance setup.


### PR DESCRIPTION
* Make instance setup on Windows wait until network can be set up. (emulate Linux)
* Refactor:
  * Use functions with early return instead of loops with break/continue
  * Remove unnecessary `net.InterfaceByIndex()` call
  * Handle an ipForwardEntry instead of individual ints
  * Wrap errors instead of sharing `msg` string