### PR TITLE
Fix compilation directives

### DIFF
--- a/google_guest_agent/accounts_unix.go
+++ b/google_guest_agent/accounts_unix.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package main

--- a/google_guest_agent/addresses_integ_test.go
+++ b/google_guest_agent/addresses_integ_test.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build integration
 // +build integration
 
 package main

--- a/google_guest_agent/addresses_unix.go
+++ b/google_guest_agent/addresses_unix.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package main

--- a/google_guest_agent/addresses_windows.go
+++ b/google_guest_agent/addresses_windows.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build windows
 // +build windows
 
 package main

--- a/google_guest_agent/instance_setup_integ_test.go
+++ b/google_guest_agent/instance_setup_integ_test.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build integration
 // +build integration
 
 package main

--- a/google_guest_agent/non_windows_accounts_integ_test.go
+++ b/google_guest_agent/non_windows_accounts_integ_test.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build integration
 // +build integration
 
 package main

--- a/google_guest_agent/stub.go
+++ b/google_guest_agent/stub.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package main


### PR DESCRIPTION
A new version of the go compiler in the testing suit requires an update of the compilation directives