### PR TITLE
Avoid conflict with automated package updates

### DIFF
--- a/google-startup-scripts.service
+++ b/google-startup-scripts.service
@@ -2,7 +2,7 @@
 Description=Google Compute Engine Startup Scripts
 Wants=network-online.target rsyslog.service
 After=network-online.target rsyslog.service google-guest-agent.service
-Before=apt-daily.service
+Before=apt-daily.service apt-daily-upgrade.service unattended-upgrades.service dnf-automatic.service dnf-automatic-install.service yum-cron.service google-osconfig-agent.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The following services on Debian and RedHat platforms (and their derivatives) implement automated updates of yum/apt packages:

- yum-cron.service (install new packages on RedHat 7 systems)
- dnf-automatic.service (download and install new packages on RedHat 8+)
- dnf-automatic-install.service (install packages previously downloaded by dnf-automatic-download.service)
- apt-daily-upgrade.service (actually installs packages downloaded by apt-daily.service)
- unattended-upgrades.serivce (security fixes on Debian)
- google-osconfig-agent.service (Google Cloud tool for fleet management)

This commit ensures that google-startup-scripts.service completes before the services listed above start. Without this change, it is relatively common for startup-scripts that install packages with yum or apt to fail due to a conflict over package database lock.

The existing block on apt-daily.service is probably sufficient since apt-daily-upgrade.service (which actually writes to the package database) runs After (in SystemD sense) it. But it's harmless to list it and it's the "real" block. It is also harmless to list units that are inactive or not defined (e.g. for the wrong operating system)

## BEFORE

`unattended-upgrade.service` is observed to start before `google-startup-scripts.service` completes:

```text
root@instance-1:~# systemctl status google-startup-scripts.service 
● google-startup-scripts.service - Google Compute Engine Startup Scripts
     Loaded: loaded (/lib/systemd/system/google-startup-scripts.service; enabled; vendo>
     Active: inactive (dead) since Fri 2023-05-19 16:07:06 UTC; 6min ago
...
root@instance-1:~# systemctl status unattended-upgrades.service 
● unattended-upgrades.service - Unattended Upgrades Shutdown
     Loaded: loaded (/lib/systemd/system/unattended-upgrades.service; enabled; vendor p>
     Active: active (running) since Fri 2023-05-19 16:07:05 UTC; 5min ago
...
```

## AFTER

`unattended-upgrade.service` is observed to start when `google-startup-scripts.service` completes:

```text
root@instance-1:~# systemctl status google-startup-scripts.service 
● google-startup-scripts.service - Google Compute Engine Startup Scripts
     Loaded: loaded (/lib/systemd/system/google-startup-scripts.service; enabled; vendo>
     Active: inactive (dead) since Fri 2023-05-19 16:14:30 UTC; 1min 15s ago
...
root@instance-1:~# systemctl status unattended-upgrades.service 
● unattended-upgrades.service - Unattended Upgrades Shutdown
     Loaded: loaded (/lib/systemd/system/unattended-upgrades.service; enabled; vendor p>
     Active: active (running) since Fri 2023-05-19 16:14:30 UTC; 1min 22s ago
...
```