### PR TITLE
Revert "Avoid conflict with automated package updates (#212)"

### DIFF
--- a/google-startup-scripts.service
+++ b/google-startup-scripts.service
@@ -2,7 +2,7 @@
 Description=Google Compute Engine Startup Scripts
 Wants=network-online.target rsyslog.service
 After=network-online.target rsyslog.service google-guest-agent.service
-Before=apt-daily.service apt-daily-upgrade.service unattended-upgrades.service dnf-automatic.service dnf-automatic-install.service yum-cron.service
+Before=apt-daily.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This reverts commit dbb10950b5cd964af10ca06bc54f768a80be1535. We should anticipate the possibility that some startup-scripts will deliberately start, for example, yum-cron.service and the prior change would cause the script to deadlock. Will explore alternative solutions.

