### PR TITLE
metadata: moving to its own package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+google_guest_agent/google_guest_agent

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/GoogleCloudPlatform/guest-agent
 
 go 1.17
 
+replace github.com/GoogleCloudPlatform/guest-agent/metadata => ../metadata
+
 require (
 	cloud.google.com/go/storage v1.22.1
 	github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20221216194522-f549ad6a1730

--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/GoogleCloudPlatform/guest-agent/utils"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 )
@@ -445,7 +446,7 @@ func (a *addressMgr) set() error {
 
 // Enables or disables IPv6 on network interfaces.
 func configureIPv6() error {
-	var newNi, oldNi networkInterfaces
+	var newNi, oldNi metadata.NetworkInterfaces
 	if len(newMetadata.Instance.NetworkInterfaces) == 0 {
 		return fmt.Errorf("no interfaces found in metadata")
 	}

--- a/google_guest_agent/addresses_test.go
+++ b/google_guest_agent/addresses_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/go-ini/ini"
 )
 
@@ -58,19 +59,19 @@ func TestAddressDisabled(t *testing.T) {
 	var tests = []struct {
 		name string
 		data []byte
-		md   *metadata
+		md   *metadata.Descriptor
 		want bool
 	}{
-		{"not explicitly disabled", []byte(""), &metadata{}, false},
-		{"enabled in cfg only", []byte("[addressManager]\ndisable=false"), &metadata{}, false},
-		{"disabled in cfg only", []byte("[addressManager]\ndisable=true"), &metadata{}, true},
-		{"disabled in cfg, enabled in instance metadata", []byte("[addressManager]\ndisable=true"), &metadata{Instance: instance{Attributes: attributes{DisableAddressManager: mkptr(false)}}}, true},
-		{"enabled in cfg, disabled in instance metadata", []byte("[addressManager]\ndisable=false"), &metadata{Instance: instance{Attributes: attributes{DisableAddressManager: mkptr(true)}}}, false},
-		{"enabled in instance metadata only", []byte(""), &metadata{Instance: instance{Attributes: attributes{DisableAddressManager: mkptr(false)}}}, false},
-		{"enabled in project metadata only", []byte(""), &metadata{Project: project{Attributes: attributes{DisableAddressManager: mkptr(false)}}}, false},
-		{"disabled in instance metadata only", []byte(""), &metadata{Instance: instance{Attributes: attributes{DisableAddressManager: mkptr(true)}}}, true},
-		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadata{Instance: instance{Attributes: attributes{DisableAddressManager: mkptr(false)}}, Project: project{Attributes: attributes{DisableAddressManager: mkptr(true)}}}, false},
-		{"disabled in project metadata only", []byte(""), &metadata{Project: project{Attributes: attributes{DisableAddressManager: mkptr(true)}}}, true},
+		{"not explicitly disabled", []byte(""), &metadata.Descriptor{}, false},
+		{"enabled in cfg only", []byte("[addressManager]\ndisable=false"), &metadata.Descriptor{}, false},
+		{"disabled in cfg only", []byte("[addressManager]\ndisable=true"), &metadata.Descriptor{}, true},
+		{"disabled in cfg, enabled in instance metadata", []byte("[addressManager]\ndisable=true"), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{DisableAddressManager: mkptr(false)}}}, true},
+		{"enabled in cfg, disabled in instance metadata", []byte("[addressManager]\ndisable=false"), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{DisableAddressManager: mkptr(true)}}}, false},
+		{"enabled in instance metadata only", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{DisableAddressManager: mkptr(false)}}}, false},
+		{"enabled in project metadata only", []byte(""), &metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{DisableAddressManager: mkptr(false)}}}, false},
+		{"disabled in instance metadata only", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{DisableAddressManager: mkptr(true)}}}, true},
+		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{DisableAddressManager: mkptr(false)}}, Project: metadata.Project{Attributes: metadata.Attributes{DisableAddressManager: mkptr(true)}}}, false},
+		{"disabled in project metadata only", []byte(""), &metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{DisableAddressManager: mkptr(true)}}}, true},
 	}
 
 	for _, tt := range tests {
@@ -95,19 +96,19 @@ func TestAddressDiff(t *testing.T) {
 	var tests = []struct {
 		name string
 		data []byte
-		md   *metadata
+		md   *metadata.Descriptor
 		want bool
 	}{
-		{"not set", []byte(""), &metadata{}, false},
-		{"enabled in cfg only", []byte("[wsfc]\nenable=true"), &metadata{}, true},
-		{"disabled in cfg only", []byte("[wsfc]\nenable=false"), &metadata{}, false},
-		{"disabled in cfg, enabled in instance metadata", []byte("[wsfc]\nenable=false"), &metadata{Instance: instance{Attributes: attributes{EnableWSFC: mkptr(true)}}}, false},
-		{"enabled in cfg, disabled in instance metadata", []byte("[wsfc]\nenable=true"), &metadata{Instance: instance{Attributes: attributes{EnableWSFC: mkptr(false)}}}, true},
-		{"enabled in instance metadata only", []byte(""), &metadata{Instance: instance{Attributes: attributes{EnableWSFC: mkptr(true)}}}, true},
-		{"enabled in project metadata only", []byte(""), &metadata{Project: project{Attributes: attributes{EnableWSFC: mkptr(true)}}}, true},
-		{"disabled in instance metadata only", []byte(""), &metadata{Instance: instance{Attributes: attributes{EnableWSFC: mkptr(false)}}}, false},
-		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadata{Instance: instance{Attributes: attributes{EnableWSFC: mkptr(true)}}, Project: project{Attributes: attributes{EnableWSFC: mkptr(false)}}}, true},
-		{"disabled in project metadata only", []byte(""), &metadata{Project: project{Attributes: attributes{EnableWSFC: mkptr(false)}}}, false},
+		{"not set", []byte(""), &metadata.Descriptor{}, false},
+		{"enabled in cfg only", []byte("[wsfc]\nenable=true"), &metadata.Descriptor{}, true},
+		{"disabled in cfg only", []byte("[wsfc]\nenable=false"), &metadata.Descriptor{}, false},
+		{"disabled in cfg, enabled in instance metadata", []byte("[wsfc]\nenable=false"), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableWSFC: mkptr(true)}}}, false},
+		{"enabled in cfg, disabled in instance metadata", []byte("[wsfc]\nenable=true"), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableWSFC: mkptr(false)}}}, true},
+		{"enabled in instance metadata only", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableWSFC: mkptr(true)}}}, true},
+		{"enabled in project metadata only", []byte(""), &metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{EnableWSFC: mkptr(true)}}}, true},
+		{"disabled in instance metadata only", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableWSFC: mkptr(false)}}}, false},
+		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableWSFC: mkptr(true)}}, Project: metadata.Project{Attributes: metadata.Attributes{EnableWSFC: mkptr(false)}}}, true},
+		{"disabled in project metadata only", []byte(""), &metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{EnableWSFC: mkptr(false)}}}, false},
 	}
 
 	for _, tt := range tests {
@@ -120,7 +121,7 @@ func TestAddressDiff(t *testing.T) {
 			cfg = &ini.File{}
 		}
 		oldWSFCEnable = false
-		oldMetadata = &metadata{}
+		oldMetadata = &metadata.Descriptor{}
 		newMetadata = tt.md
 		config = cfg
 		got := (&addressMgr{}).diff()
@@ -149,7 +150,7 @@ func TestWsfcFilter(t *testing.T) {
 
 	config = ini.Empty()
 	for idx, tt := range tests {
-		var md metadata
+		var md metadata.Descriptor
 		if err := json.Unmarshal(tt.metaDataJSON, &md); err != nil {
 			t.Error("failed to unmarshal test JSON:", tt, err)
 		}
@@ -171,13 +172,13 @@ func TestWsfcFilter(t *testing.T) {
 
 func TestWsfcFlagTriggerAddressDiff(t *testing.T) {
 	var tests = []struct {
-		newMetadata, oldMetadata *metadata
+		newMetadata, oldMetadata *metadata.Descriptor
 	}{
 		// trigger diff on wsfc-addrs
-		{&metadata{Instance: instance{Attributes: attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata{}},
-		{&metadata{Project: project{Attributes: attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata{}},
-		{&metadata{Instance: instance{Attributes: attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata{Instance: instance{Attributes: attributes{WSFCAddresses: "192.168.0.2"}}}},
-		{&metadata{Project: project{Attributes: attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata{Project: project{Attributes: attributes{WSFCAddresses: "192.168.0.2"}}}},
+		{&metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata.Descriptor{}},
+		{&metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata.Descriptor{}},
+		{&metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{WSFCAddresses: "192.168.0.2"}}}},
+		{&metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{WSFCAddresses: "192.168.0.1"}}}, &metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{WSFCAddresses: "192.168.0.2"}}}},
 	}
 
 	config = ini.Empty()

--- a/google_guest_agent/diagnostics.go
+++ b/google_guest_agent/diagnostics.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"sync/atomic"
 
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/GoogleCloudPlatform/guest-agent/utils"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 )
@@ -42,15 +43,7 @@ type diagnosticsEntry struct {
 }
 
 func (k diagnosticsEntry) expired() bool {
-	expired, err := utils.CheckExpired(k.ExpireOn)
-	if err != nil {
-		if !utils.ContainsString(k.ExpireOn, badExpire) {
-			logger.Errorf("error parsing time: %s", err)
-			badExpire = append(badExpire, k.ExpireOn)
-		}
-		return true
-	}
-	return expired
+	return metadata.Expired(k.ExpireOn)
 }
 
 type diagnosticsMgr struct{}

--- a/google_guest_agent/diagnostics_test.go
+++ b/google_guest_agent/diagnostics_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/go-ini/ini"
 )
 
@@ -43,19 +44,19 @@ func TestDiagnosticsDisabled(t *testing.T) {
 	var tests = []struct {
 		name string
 		data []byte
-		md   *metadata
+		md   *metadata.Descriptor
 		want bool
 	}{
-		{"not explicitly enabled", []byte(""), &metadata{}, false},
-		{"enabled in cfg only", []byte("[diagnostics]\nenable=true"), &metadata{}, false},
-		{"disabled in cfg only", []byte("[diagnostics]\nenable=false"), &metadata{}, true},
-		{"disabled in cfg, enabled in instance metadata", []byte("[diagnostics]\nenable=false"), &metadata{Instance: instance{Attributes: attributes{EnableDiagnostics: mkptr(true)}}}, true},
-		{"enabled in cfg, disabled in instance metadata", []byte("[diagnostics]\nenable=true"), &metadata{Instance: instance{Attributes: attributes{EnableDiagnostics: mkptr(false)}}}, false},
-		{"enabled in instance metadata only", []byte(""), &metadata{Instance: instance{Attributes: attributes{EnableDiagnostics: mkptr(true)}}}, false},
-		{"enabled in project metadata only", []byte(""), &metadata{Project: project{Attributes: attributes{EnableDiagnostics: mkptr(true)}}}, false},
-		{"disabled in instance metadata only", []byte(""), &metadata{Instance: instance{Attributes: attributes{EnableDiagnostics: mkptr(false)}}}, true},
-		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadata{Instance: instance{Attributes: attributes{EnableDiagnostics: mkptr(true)}}, Project: project{Attributes: attributes{EnableDiagnostics: mkptr(false)}}}, false},
-		{"disabled in project metadata only", []byte(""), &metadata{Project: project{Attributes: attributes{EnableDiagnostics: mkptr(false)}}}, true},
+		{"not explicitly enabled", []byte(""), &metadata.Descriptor{}, false},
+		{"enabled in cfg only", []byte("[diagnostics]\nenable=true"), &metadata.Descriptor{}, false},
+		{"disabled in cfg only", []byte("[diagnostics]\nenable=false"), &metadata.Descriptor{}, true},
+		{"disabled in cfg, enabled in instance metadata", []byte("[diagnostics]\nenable=false"), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(true)}}}, true},
+		{"enabled in cfg, disabled in instance metadata", []byte("[diagnostics]\nenable=true"), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(false)}}}, false},
+		{"enabled in instance metadata only", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(true)}}}, false},
+		{"enabled in project metadata only", []byte(""), &metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(true)}}}, false},
+		{"disabled in instance metadata only", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(false)}}}, true},
+		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadata.Descriptor{Instance: metadata.Instance{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(true)}}, Project: metadata.Project{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(false)}}}, false},
+		{"disabled in project metadata only", []byte(""), &metadata.Descriptor{Project: metadata.Project{Attributes: metadata.Attributes{EnableDiagnostics: mkptr(false)}}}, true},
 	}
 
 	for _, tt := range tests {

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/GoogleCloudPlatform/guest-agent/utils"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"github.com/go-ini/ini"
@@ -39,7 +40,7 @@ var (
 	programName              = "GCEGuestAgent"
 	version                  string
 	ticker                   = time.Tick(70 * time.Second)
-	oldMetadata, newMetadata *metadata
+	oldMetadata, newMetadata *metadata.Descriptor
 	config                   *ini.File
 	osRelease                release
 	action                   string
@@ -131,7 +132,7 @@ func run(ctx context.Context) {
 	}
 
 	var err error
-	newMetadata, err = getMetadata(ctx, false)
+	newMetadata, err = metadata.Get(ctx)
 	if err == nil {
 		opts.ProjectName = newMetadata.Project.ProjectID
 	}
@@ -161,11 +162,11 @@ func run(ctx context.Context) {
 	agentInit(ctx)
 
 	go func() {
-		oldMetadata = &metadata{}
+		oldMetadata = &metadata.Descriptor{}
 		webError := 0
 		for {
 			var err error
-			newMetadata, err = watchMetadata(ctx)
+			newMetadata, err = metadata.Watch(ctx)
 			if err != nil {
 				// Only log the second web error to avoid transient errors and
 				// not to spam the log on network failures.

--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 )
 
@@ -36,7 +37,7 @@ type osloginMgr struct{}
 
 // We also read project keys first, letting instance-level keys take
 // precedence.
-func getOSLoginEnabled(md *metadata) (bool, bool, bool) {
+func getOSLoginEnabled(md *metadata.Descriptor) (bool, bool, bool) {
 	var enable bool
 	if md.Project.Attributes.EnableOSLogin != nil {
 		enable = *md.Project.Attributes.EnableOSLogin
@@ -129,7 +130,7 @@ func (o *osloginMgr) set() error {
 	}
 
 	now := fmt.Sprintf("%d", time.Now().Unix())
-	writeGuestAttributes("guest-agent/sshable", now)
+	metadata.WriteGuestAttributes("guest-agent/sshable", now)
 
 	if enable {
 		logger.Debugf("Create OS Login dirs, if needed")

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 )
 
 func TestFilterGoogleLines(t *testing.T) {
@@ -524,7 +526,7 @@ func TestGetOSLoginEnabled(t *testing.T) {
 	}
 
 	for idx, tt := range tests {
-		var md metadata
+		var md metadata.Descriptor
 		if err := json.Unmarshal([]byte(tt.md), &md); err != nil {
 			t.Errorf("Failed to unmarshal metadata JSON for test %v: %v", idx, err)
 		}

--- a/google_guest_agent/wsfc_test.go
+++ b/google_guest_agent/wsfc_test.go
@@ -22,33 +22,34 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/go-ini/ini"
 )
 
-func setEnableWSFC(md metadata, enabled *bool) *metadata {
+func setEnableWSFC(md metadata.Descriptor, enabled *bool) *metadata.Descriptor {
 	md.Instance.Attributes.EnableWSFC = enabled
 	return &md
 }
 
-func setWSFCAddresses(md metadata, wsfcAddresses string) *metadata {
+func setWSFCAddresses(md metadata.Descriptor, wsfcAddresses string) *metadata.Descriptor {
 	md.Instance.Attributes.WSFCAddresses = wsfcAddresses
 	return &md
 }
 
-func setWSFCAgentPort(md metadata, wsfcPort string) *metadata {
+func setWSFCAgentPort(md metadata.Descriptor, wsfcPort string) *metadata.Descriptor {
 	md.Instance.Attributes.WSFCAgentPort = wsfcPort
 	return &md
 }
 
 var (
 	testAgent    = getWsfcAgentInstance()
-	testMetadata = metadata{}
+	testMetadata = metadata.Descriptor{}
 	testListener = &net.TCPListener{}
 )
 
 func TestNewWsfcManager(t *testing.T) {
 	type args struct {
-		newMetadata *metadata
+		newMetadata *metadata.Descriptor
 	}
 	tests := []struct {
 		name string

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package main
+package metadata
 
 import (
 	"context"
@@ -46,17 +46,17 @@ func TestWatchMetadata(t *testing.T) {
 
 	truebool := new(bool)
 	*truebool = true
-	want := attributes{
+	want := Attributes{
 		EnableOSLogin: truebool,
 		WSFCAddresses: "foo",
-		WindowsKeys: windowsKeys{
-			windowsKey{Exponent: "exponent", UserName: "username", Modulus: "modulus", ExpireOn: et, AddToAdministrators: nil},
-			windowsKey{Exponent: "exponent", UserName: "username", Modulus: "modulus", ExpireOn: et, AddToAdministrators: func() *bool { ret := true; return &ret }()},
+		WindowsKeys: WindowsKeys{
+			WindowsKey{Exponent: "exponent", UserName: "username", Modulus: "modulus", ExpireOn: et, AddToAdministrators: nil},
+			WindowsKey{Exponent: "exponent", UserName: "username", Modulus: "modulus", ExpireOn: et, AddToAdministrators: func() *bool { ret := true; return &ret }()},
 		},
 		SSHKeys: []string{"name:ssh-rsa [KEY] hostname", "name:ssh-rsa [KEY] hostname"},
 	}
 	for _, e := range []string{etag1, etag2} {
-		got, err := watchMetadata(context.Background())
+		got, err := Watch(context.Background())
 		if err != nil {
 			t.Fatalf("error running watchMetadata: %v", err)
 		}
@@ -91,7 +91,7 @@ func TestBlockProjectKeys(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		var md metadata
+		var md Descriptor
 		if err := json.Unmarshal([]byte(test.json), &md); err != nil {
 			t.Errorf("failed to unmarshal JSON: %v", err)
 		}

--- a/metadata/windows.go
+++ b/metadata/windows.go
@@ -1,0 +1,64 @@
+package metadata
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/guest-agent/utils"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+)
+
+var (
+	badKeys   []string
+	badExpire []string
+)
+
+// WindowsKey describes the WindowsKey metadata keys.
+type WindowsKey struct {
+	Email               string
+	ExpireOn            string
+	Exponent            string
+	Modulus             string
+	UserName            string
+	HashFunction        string
+	AddToAdministrators *bool
+	PasswordLength      int
+}
+
+// WindowsKeys is a slice of WindowKey.
+type WindowsKeys []WindowsKey
+
+// Expired check if a given expired key is valid or not.
+func Expired(expireOn string) bool {
+	expired, err := utils.CheckExpired(expireOn)
+	if err != nil {
+		if !utils.ContainsString(expireOn, badExpire) {
+			logger.Errorf("error parsing time: %s", err)
+			badExpire = append(badExpire, expireOn)
+		}
+		return true
+	}
+	return expired
+}
+
+// UnmarshalJSON unmarshals b into WindowsKeys.
+func (k *WindowsKeys) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	for _, jskey := range strings.Split(s, "\n") {
+		var wk WindowsKey
+		if err := json.Unmarshal([]byte(jskey), &wk); err != nil {
+			if !utils.ContainsString(jskey, badKeys) {
+				logger.Errorf("failed to unmarshal windows key from metadata: %s", err)
+				badKeys = append(badKeys, jskey)
+			}
+			continue
+		}
+		if wk.Exponent != "" && wk.Modulus != "" && wk.UserName != "" && !Expired(wk.ExpireOn) {
+			*k = append(*k, wk)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Creating a separation between the core implementation and metadata will give us the flexibility to move internals as required without breaking the agent and managers specifics.

No behavior has changed, the current coverage shoud be enough for now.