### PR TITLE
sshTrustedCA: add pipe event handler

### DIFF
--- a/google_guest_agent/.gitignore
+++ b/google_guest_agent/.gitignore
@@ -1,0 +1,1 @@
+google_guest_agent.exe

--- a/google_guest_agent/events/events.go
+++ b/google_guest_agent/events/events.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events/metadata"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events/sshtrustedca"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 )
 
@@ -87,6 +88,7 @@ type eventBusData struct {
 func init() {
 	err := initWatchers([]Watcher{
 		metadata.New(),
+		sshtrustedca.New(sshtrustedca.DefaultPipePath),
 	})
 	if err != nil {
 		logger.Errorf("Failed to initialize watchers: %+v", err)

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca.go
@@ -1,0 +1,53 @@
+//  Copyright 2023 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package sshtrustedca implement the sshd trusted ca cert pipe events watcher.
+package sshtrustedca
+
+import (
+	"os"
+)
+
+const (
+	// WatcherID is the sshtrustedca watcher's ID.
+	WatcherID = "ssh-trusted-ca-pipe-watcher"
+	// ReadEvent is the sshtrustedca's read event type ID.
+	ReadEvent = "ssh-trusted-ca-pipe-watcher,read"
+	// DefaultPipePath defines the default ssh trusted ca pipe path.
+	DefaultPipePath = "/etc/ssh/oslogin_trustedca.pub"
+)
+
+// Watcher is the sshtrustedca event watcher implementation.
+type Watcher struct {
+	pipePath string
+}
+
+// PipeData wraps the pipe event data.
+type PipeData struct {
+	// File is the writeonly pipe's file descriptor. The user/handler must
+	// make sure to close it after processing the event.
+	File *os.File
+}
+
+// New allocates and initializes a new Watcher.
+func New(pipePath string) *Watcher {
+	return &Watcher{
+		pipePath: pipePath,
+	}
+}
+
+// ID returns the sshtrustedca event watcher id.
+func (mp *Watcher) ID() string {
+	return WatcherID
+}

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca_linux.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca_linux.go
@@ -1,0 +1,99 @@
+//  Copyright 2023 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package sshtrustedca
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+)
+
+// Create a named pipe if it doesn't exist.
+func createNamedPipe(pipePath string) error {
+	pipeDir := filepath.Dir(pipePath)
+	_, err := os.Stat(pipeDir)
+
+	if err != nil && os.IsNotExist(err) {
+		// The perm 0755 is compatible with distros /etc/ssh/ directory.
+		if err := os.MkdirAll(pipeDir, 0755); err != nil {
+			return err
+		}
+	}
+
+	if _, err := os.Stat(pipePath); err != nil {
+		if os.IsNotExist(err) {
+			if err := syscall.Mkfifo(pipePath, 0644); err != nil {
+				return fmt.Errorf("failed to create named pipe: %+v", err)
+			}
+		} else {
+			return fmt.Errorf("failed to stat file: " + pipePath)
+		}
+	}
+	return nil
+}
+
+// Run listens to ssh_trusted_ca's pipe open calls and report back the event.
+func (mp *Watcher) Run(ctx context.Context) (bool, string, interface{}, error) {
+	var canceled bool
+
+	// Cancelation handling code.
+	go func() {
+		select {
+		case <-ctx.Done():
+			canceled = true
+
+			// Open the pipe as O_RDONLY to release the blocking open O_WRONLY.
+			pipeFile, err := os.OpenFile(mp.pipePath, os.O_RDONLY, 0644)
+			if err != nil {
+				logger.Errorf("Failed to open readonly pipe: %+v", err)
+				return
+			}
+
+			defer func() {
+				if err := pipeFile.Close(); err != nil {
+					logger.Errorf("Failed to close readonly pipe: %+v", err)
+				}
+			}()
+		}
+	}()
+
+	// If the configured named pipe doesn't exists we create it before emitting events
+	// from it.
+	if err := createNamedPipe(mp.pipePath); err != nil {
+		return true, ReadEvent, nil, err
+	}
+
+	// Open the pipe as writeonly, it will block until a read is performed from the
+	// other end of the pipe.
+	pipeFile, err := os.OpenFile(mp.pipePath, os.O_WRONLY, 0644)
+	if err != nil {
+		return true, ReadEvent, nil, err
+	}
+
+	// Have we got a ctx.Done()? if so lets just return from here and unregister
+	// the watcher.
+	if canceled {
+		if err := pipeFile.Close(); err != nil {
+			logger.Errorf("Failed to close readonly pipe: %+v", err)
+		}
+		return false, ReadEvent, nil, nil
+	}
+
+	return true, ReadEvent, &PipeData{File: pipeFile}, nil
+}

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca_linux_test.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca_linux_test.go
@@ -1,0 +1,122 @@
+//  Copyright 2023 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package sshtrustedca
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+func TestPipe(t *testing.T) {
+	// Putting a directory name between temp dir and the file name guarantees we test
+	// the directory creation.
+	pipePath := path.Join(t.TempDir(), "ssh", "oslogin_trustedca.pub")
+	watcher := New(pipePath)
+	testData := "test data transmited through the pipe."
+
+	if watcher.ID() != WatcherID {
+		t.Errorf("Wrong watcher id, expected %s, got %s", WatcherID, watcher.ID())
+	}
+
+	timer := time.NewTimer(1 * time.Second)
+
+	// This go routine simulates the reading end of the pipe, it will until the timer
+	// is triggered (giving enough time for the Watcher to setup the pipe), when the
+	// read operation happened the Watcher will unblock returning to the test and
+	// the test implementation will write to the writing end of the pipe.
+	go func() {
+		<-timer.C
+		readFile, err := os.OpenFile(pipePath, os.O_RDONLY, 0644)
+		if err != nil {
+			t.Errorf("Failed to open the read end of the pipe: %+v", err)
+			return
+		}
+
+		defer func() {
+			if err := readFile.Close(); err != nil {
+				t.Errorf("Failed to close pipe(read end) file: %+v", err)
+			}
+		}()
+
+		buff := make([]byte, 1024)
+		var output string
+
+		for {
+			n, err := readFile.Read(buff)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Errorf("Failed to read pipe: %+v", err)
+				return
+			}
+			if n > 0 {
+				output = fmt.Sprintf("%s%s", output, buff[:n])
+			}
+		}
+
+		if output != testData {
+			t.Errorf("Wrong data read from the pipe, expected %s, got %s", testData, output)
+		}
+	}()
+
+	_, _, evData, err := watcher.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Watcher failed: %+v", err)
+	}
+	pipeData := evData.(*PipeData)
+
+	defer func() {
+		if err := pipeData.File.Close(); err != nil {
+			t.Fatalf("Failed to close pipe(write end) file: %+v", err)
+		}
+	}()
+
+	pipeData.File.WriteString(testData)
+}
+
+func TestCancel(t *testing.T) {
+	pipePath := path.Join(t.TempDir(), "ssh", "oslogin_trustedca.pub")
+	watcher := New(pipePath)
+
+	sync := make(chan bool)
+	defer close(sync)
+
+	cancelTimer := time.NewTimer((1 * time.Second) / 2)
+	timeoutTimer := time.NewTimer(1 * time.Second)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		<-cancelTimer.C
+		ctxCancel()
+		sync <- true
+	}()
+
+	go func() {
+		select {
+		case <-timeoutTimer.C:
+			t.Error("Watcher should have been canceled before timeout.")
+		case <-sync:
+			return
+		}
+	}()
+
+	watcher.Run(ctx)
+}

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca_windows.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca_windows.go
@@ -1,0 +1,25 @@
+//  Copyright 2023 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package sshtrustedca
+
+import (
+	"context"
+	"fmt"
+)
+
+// Run is a no-op implementation for windows.
+func (mp *Watcher) Run(ctx context.Context) (bool, string, interface{}, error) {
+	return false, ReadEvent, nil, fmt.Errorf("SSH Trusted CA cert pipe Watcher is not yet implemented for windows.")
+}


### PR DESCRIPTION
The integration between sshd and metadata uses a named pipe, that gives us the flexibility to read the certificate data from metadata on demand.

The implementation lays on top of the events layer, when a open operation is performed on the pipe the sshTrustedCA watcher will open as write only, notify its subscribers of the event(passing down the open file), the subscriber is responsible to close the file. If multiple subscribers exist their implementation should coordinate when and how to close the pipe.