### PR TITLE
ssh_trusted_ca: enable the feature

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events/sshtrustedca"
 	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 )
@@ -200,7 +201,10 @@ func updateSSHConfig(sshConfig string, enable, twofactor, skey bool) string {
 		}
 	}
 	authorizedKeysUser := "AuthorizedKeysCommandUser root"
-	trustedUserCAKeys := "TrustedUserCAKeys /etc/ssh/trustedca.pub"
+
+	// TODO: only enable this key configuration if certs mechanism is enabled
+	trustedUserCAKeys := "TrustedUserCAKeys " + sshtrustedca.DefaultPipePath
+
 	twoFactorAuthMethods := "AuthenticationMethods publickey,keyboard-interactive"
 	if (osRelease.os == "rhel" || osRelease.os == "centos") && osRelease.version.major == 6 {
 		authorizedKeysUser = "AuthorizedKeysCommandRunAs root"

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events/sshtrustedca"
 	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 )
 
@@ -186,7 +187,7 @@ func TestUpdateSSHConfig(t *testing.T) {
 	authorizedKeysCommand := "AuthorizedKeysCommand /usr/bin/google_authorized_keys"
 	authorizedKeysCommandSk := "AuthorizedKeysCommand /usr/bin/google_authorized_keys_sk"
 	authorizedKeysUser := "AuthorizedKeysCommandUser root"
-	trustedUserCAKeys := "TrustedUserCAKeys /etc/ssh/trustedca.pub"
+	trustedUserCAKeys := "TrustedUserCAKeys " + sshtrustedca.DefaultPipePath
 	twoFactorAuthMethods := "AuthenticationMethods publickey,keyboard-interactive"
 	matchblock1 := `Match User sa_*`
 	matchblock2 := `       AuthenticationMethods publickey`


### PR DESCRIPTION
Conditionally enable the event watcher and introduce the write end of the pipe implementation. Additionally we are introducing a new metadata client method to get one specific key (rather than the whole descriptor).