### PR TITLE
metadata: pass main context to WriteGuestAttributes()

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -283,7 +284,7 @@ func (a *addressMgr) disabled(os string) (disabled bool) {
 	return !config.Section("Daemons").Key("network_daemon").MustBool(true)
 }
 
-func (a *addressMgr) set() error {
+func (a *addressMgr) set(ctx context.Context) error {
 	if runtime.GOOS == "windows" {
 		a.applyWSFCFilter()
 	}

--- a/google_guest_agent/clock.go
+++ b/google_guest_agent/clock.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"os/exec"
 	"runtime"
 
@@ -36,7 +37,7 @@ func (a *clockskewMgr) disabled(os string) (disabled bool) {
 	return os == "windows" || !enabled
 }
 
-func (a *clockskewMgr) set() error {
+func (a *clockskewMgr) set(ctx context.Context) error {
 	if runtime.GOOS == "freebsd" {
 		err := runCmd(exec.Command("service", "ntpd", "status"))
 		if err == nil {

--- a/google_guest_agent/diagnostics.go
+++ b/google_guest_agent/diagnostics.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"os/exec"
 	"reflect"
@@ -80,7 +81,7 @@ func (d *diagnosticsMgr) disabled(os string) (disabled bool) {
 	return diagnosticsDisabled
 }
 
-func (d *diagnosticsMgr) set() error {
+func (d *diagnosticsMgr) set(ctx context.Context) error {
 	logger.Infof("Diagnostics: logs export requested.")
 	diagnosticsEntries, err := readRegMultiString(regKeyBase, diagnosticsRegKey)
 	if err != nil && err != errRegNotExist {

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -174,7 +174,7 @@ func agentInit(ctx context.Context) {
 			if newMetadata.Instance.ID.String() != strings.TrimSpace(string(instanceID)) {
 				logger.Infof("Instance ID changed, running first-boot actions")
 				if config.Section("InstanceSetup").Key("set_host_keys").MustBool(true) {
-					if err := generateSSHKeys(); err != nil {
+					if err := generateSSHKeys(ctx); err != nil {
 						logger.Warningf("Failed to generate SSH keys: %v", err)
 					}
 				}
@@ -195,7 +195,7 @@ func agentInit(ctx context.Context) {
 	}
 }
 
-func generateSSHKeys() error {
+func generateSSHKeys(ctx context.Context) error {
 	hostKeyDir := config.Section("InstanceSetup").Key("host_key_dir").MustString("/etc/ssh")
 	dir, err := os.Open(hostKeyDir)
 	if err != nil {
@@ -257,7 +257,7 @@ func generateSSHKeys() error {
 			continue
 		}
 		if vals := strings.Split(string(pubKey), " "); len(vals) >= 2 {
-			if err := mdsClient.WriteGuestAttributes(context.Background(), "hostkeys/"+vals[0], vals[1]); err != nil {
+			if err := mdsClient.WriteGuestAttributes(ctx, "hostkeys/"+vals[0], vals[1]); err != nil {
 				logger.Errorf("Failed to upload %s key to guest attributes: %v", keytype, err)
 			}
 		} else {

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -57,7 +57,7 @@ const (
 type manager interface {
 	diff() bool
 	disabled(string) bool
-	set() error
+	set(ctx context.Context) error
 	timeout() bool
 }
 
@@ -88,7 +88,7 @@ func closeFile(c io.Closer) {
 	}
 }
 
-func runUpdate() {
+func runUpdate(ctx context.Context) {
 	var wg sync.WaitGroup
 	mgrs := []manager{&addressMgr{}}
 	switch runtime.GOOS {
@@ -110,7 +110,7 @@ func runUpdate() {
 				return
 			}
 			logger.Debugf("running %#v manager", mgr)
-			if err := mgr.set(); err != nil {
+			if err := mgr.set(ctx); err != nil {
 				logger.Errorf("error running %#v manager: %s", mgr, err)
 			}
 		}(mgr)
@@ -233,7 +233,7 @@ func run(ctx context.Context) {
 		}
 
 		newMetadata = evData.Data.(*metadata.Descriptor)
-		runUpdate()
+		runUpdate(ctx)
 		oldMetadata = newMetadata
 
 		return true

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -107,7 +108,7 @@ func (a *accountsMgr) disabled(os string) bool {
 		!config.Section("Daemons").Key("accounts_daemon").MustBool(true)
 }
 
-func (a *accountsMgr) set() error {
+func (a *accountsMgr) set(ctx context.Context) error {
 	if sshKeys == nil {
 		logger.Debugf("initialize sshKeys map")
 		sshKeys = make(map[string][]string)

--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -82,7 +82,7 @@ func (o *osloginMgr) disabled(os string) bool {
 	return os == "windows"
 }
 
-func (o *osloginMgr) set() error {
+func (o *osloginMgr) set(ctx context.Context) error {
 	// We need to know if it was previously enabled for the clearing of
 	// metadata-based SSH keys.
 	oldEnable, _, _ := getOSLoginEnabled(oldMetadata)
@@ -92,7 +92,7 @@ func (o *osloginMgr) set() error {
 		logger.Infof("Enabling OS Login")
 		newMetadata.Instance.Attributes.SSHKeys = nil
 		newMetadata.Project.Attributes.SSHKeys = nil
-		(&accountsMgr{}).set()
+		(&accountsMgr{}).set(ctx)
 	}
 
 	if !enable && oldEnable {
@@ -132,7 +132,7 @@ func (o *osloginMgr) set() error {
 	}
 
 	now := fmt.Sprintf("%d", time.Now().Unix())
-	mdsClient.WriteGuestAttributes(context.Background(), "guest-agent/sshable", now)
+	mdsClient.WriteGuestAttributes(ctx, "guest-agent/sshable", now)
 
 	if enable {
 		logger.Debugf("Create OS Login dirs, if needed")

--- a/google_guest_agent/windows_accounts.go
+++ b/google_guest_agent/windows_accounts.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -327,7 +328,7 @@ func verifyWinSSHVersion() error {
 	return versionOk(sshdVersion, minSSHVersion)
 }
 
-func (a *winAccountsMgr) set() error {
+func (a *winAccountsMgr) set(ctx context.Context) error {
 	oldSSHEnable := getWinSSHEnabled(oldMetadata)
 	sshEnable := getWinSSHEnabled(newMetadata)
 

--- a/google_guest_agent/wsfc.go
+++ b/google_guest_agent/wsfc.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"net"
 	"strings"
 	"sync"
@@ -108,7 +109,7 @@ func (m *wsfcManager) timeout() bool {
 // Diff will always be called before set. So in set, only two cases are possible:
 // - state changed: start or stop the wsfc agent accordingly
 // - port changed: restart the agent if it is running
-func (m *wsfcManager) set() error {
+func (m *wsfcManager) set(ctx context.Context) error {
 	m.agent.setPort(m.agentNewPort)
 
 	// if state changes

--- a/google_guest_agent/wsfc_test.go
+++ b/google_guest_agent/wsfc_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -150,7 +151,7 @@ func TestWsfcManagerSet(t *testing.T) {
 		{"set do nothing", &wsfcManager{agentNewState: stopped, agentNewPort: "1", agent: &mockAgent{state: stopped, port: "0"}}, false, false, false},
 	}
 	for _, tt := range tests {
-		if err := tt.m.set(); (err != nil) != tt.wantErr {
+		if err := tt.m.set(context.Background()); (err != nil) != tt.wantErr {
 			t.Errorf("wsfcManager.set() error = %v, wantErr %v", err, tt.wantErr)
 		}
 
@@ -184,7 +185,7 @@ func getHealthCheckResponce(request string, agent healthAgent) (string, error) {
 func TestWsfcRunAgentE2E(t *testing.T) {
 
 	wsfcMgr := &wsfcManager{agentNewState: running, agentNewPort: wsfcDefaultAgentPort, agent: getWsfcAgentInstance()}
-	wsfcMgr.set()
+	wsfcMgr.set(context.Background())
 
 	// make sure the agent is cleaned up.
 	defer wsfcMgr.agent.stop()
@@ -222,7 +223,7 @@ func TestWsfcRunAgentE2E(t *testing.T) {
 
 	// test stop agent
 	wsfcMgrStop := &wsfcManager{agentNewState: stopped, agent: getWsfcAgentInstance()}
-	wsfcMgrStop.set()
+	wsfcMgrStop.set(context.Background())
 	if _, err := getHealthCheckResponce(existIP, wsfcMgr.agent); err == nil {
 		t.Errorf("health check still running after calling stop")
 	}


### PR DESCRIPTION
The calls to metadata.WriteGuestAttributes() were using a background context, this patch changes it to start using the main context, in order to be able to pass it down on its callers it was necessary to change the manager's interface to add ctx as a parameter to set() method.