### PR TITLE
metadata event handler: don't run update if metadata is nil

### DIFF
--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -233,6 +233,11 @@ func run(ctx context.Context) {
 		}
 
 		newMetadata = evData.Data.(*metadata.Descriptor)
+		if newMetadata == nil {
+			logger.Info("Metadata event watcher didn't pass in the metadata, ignoring.")
+			return true
+		}
+
 		runUpdate(ctx)
 		oldMetadata = newMetadata
 


### PR DESCRIPTION
We shouldn't do anything (i.e. updating configuration) if the metadata passed in by the event watcher is nil.

Additionally this patch introduces a event test where we are using complex data (namely a struct) to be passed from the watcher to the handler.