### PR TITLE
metadata: remove the sleep around metadata in instance setup

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -142,7 +142,6 @@ func agentInit(ctx context.Context) {
 		for newMetadata == nil {
 			logger.Debugf("populate first time metadata...")
 			newMetadata, _ = mdsClient.Get(ctx)
-			time.Sleep(1 * time.Second)
 		}
 
 		// Disable overcommit accounting; e2 instances only.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -50,7 +50,6 @@ type MDSClientInterface interface {
 
 // requestConfig is used internally to configure an http request given its context.
 type requestConfig struct {
-	method     string
 	baseURL    string
 	hang       bool
 	recursive  bool
@@ -280,7 +279,6 @@ func (c *Client) retry(ctx context.Context, cfg requestConfig) (string, error) {
 // GetKey gets a specific metadata key.
 func (c *Client) GetKey(ctx context.Context, key string) (string, error) {
 	cfg := requestConfig{
-		method:  "GET",
 		baseURL: c.metadataURL + key,
 	}
 	return c.retry(ctx, cfg)
@@ -298,7 +296,6 @@ func (c *Client) Get(ctx context.Context) (*Descriptor, error) {
 
 func (c *Client) get(ctx context.Context, hang bool) (*Descriptor, error) {
 	cfg := requestConfig{
-		method:  "GET",
 		baseURL: c.metadataURL,
 		timeout: defaultTimeout,
 	}
@@ -367,7 +364,7 @@ func (c *Client) do(ctx context.Context, cfg requestConfig) (string, error) {
 		finalURL = fmt.Sprintf("%s/?%s", finalURL, strings.Join(urlTokens, "&"))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, cfg.method, finalURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", finalURL, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We introduced a retry strategy within metadata client before, we don't need to implement retries in the core implementation.

This patch removes the sleep in the `agentInit()` function, we still keep retrying if we can't get a metadata descriptor for backward compatibility - it will get changed whenever we change the network initialization code, for now we are just avoiding the `sleep()` call.

Additionally this patch removes the unwanted and not necessary method in the `requestConfig` struct in the metadata package since we are using this infrastructure code for "GET" requests.