### PR TITLE
metadata event handler: updates and bug fixes

### DIFF
--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -232,6 +232,11 @@ func run(ctx context.Context) {
 			return true
 		}
 
+		if evData.Data == nil {
+			logger.Infof("Metadata event watcher didn't pass in the metadata, ignoring.")
+			return true
+		}
+
 		newMetadata = evData.Data.(*metadata.Descriptor)
 		runUpdate(ctx)
 		oldMetadata = newMetadata


### PR DESCRIPTION
Metadata handler:
We shouldn't do anything (i.e. updating configuration) if the metadata passed in by the event watcher is nil.

Event Manager:
Fix an issue with event manager layer where the context and the sync channels were being handled as mutually exclusive causing the event manager to never "abort" after a cancel if the callbacks handler go routines are already setup and running.

Event Handler Test:
Added a test to exercise a call to cancel the context after the callback handlers go routines are already setup and running.