### PR TITLE
metadata: don't try to use metadata before agentInit() is done

### DIFF
--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -130,16 +130,9 @@ func run(ctx context.Context) {
 		// Local logging is syslog; we will just use stdout in Linux.
 		opts.DisableLocalLogging = true
 	}
+
 	if os.Getenv("GUEST_AGENT_DEBUG") != "" {
 		opts.Debug = true
-	}
-
-	mdsClient = metadata.New()
-
-	var err error
-	newMetadata, err = mdsClient.Get(ctx)
-	if err == nil {
-		opts.ProjectName = newMetadata.Project.ProjectID
 	}
 
 	if err := logger.Init(ctx, opts); err != nil {
@@ -156,6 +149,7 @@ func run(ctx context.Context) {
 		cfgfile = winConfigPath
 	}
 
+	var err error
 	config, err = parseConfig(cfgfile)
 	if err != nil && !os.IsNotExist(err) {
 		logger.Errorf("Error parsing config %s: %s", cfgfile, err)
@@ -171,6 +165,16 @@ func run(ctx context.Context) {
 			logger.Debugf("Error getting metdata: %v", err)
 		}
 	}
+
+	// Try to re-initialize logger now, we know after agentInit() is more likely to have metadata available.
+	// TODO: move all this metadata dependent code to its own metadata event handler.
+	if newMetadata != nil {
+		opts.ProjectName = newMetadata.Project.ProjectID
+		if err := logger.Init(ctx, opts); err != nil {
+			logger.Errorf("Error initializing logger: %v", err)
+		}
+	}
+
 	// Only record telemetry if we have metdata, and telemetry isnt disabled.
 	// Telemetry should onlyt be recorded once in an agents lifetime and is done on a best effort basis.
 	if newMetadata != nil && !newMetadata.Instance.Attributes.DisableTelemetry && !newMetadata.Project.Attributes.DisableTelemetry {


### PR DESCRIPTION
Avoid adding metadata dependent code before agentInit() is done and the routes are not certain to be ready. This avoid blocking too long before sending systemd-notify signal.

The logger then requires to have another attempt to configure the cloud logging client after we have metadata ready/available since the project name is a dependency to it and we use metadata to determine its value/name.