### PR TITLE
metadata: properly set request config

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -317,14 +317,14 @@ func (c *Client) Get(ctx context.Context) (*Descriptor, error) {
 
 func (c *Client) get(ctx context.Context, hang bool) (*Descriptor, error) {
 	cfg := requestConfig{
-		baseURL: c.metadataURL,
-		timeout: defaultTimeout,
+		baseURL:    c.metadataURL,
+		timeout:    defaultTimeout,
+		recursive:  true,
+		jsonOutput: true,
 	}
 
 	if hang {
 		cfg.hang = true
-		cfg.recursive = true
-		cfg.jsonOutput = true
 	}
 
 	resp, err := c.retry(ctx, cfg)


### PR DESCRIPTION
JsonOutput and recursive should always be true for both Get() and Watch() being the difference only the hang flag. This code path doesn't affect GetKey() (that shouldn't have JsonOutput and recursive flags set).