### PR TITLE
sshtrustedca watcher: fix concurrency error

### DIFF
--- a/google_guest_agent/events/sshtrustedca/sshtrustedca.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca.go
@@ -17,6 +17,7 @@ package sshtrustedca
 
 import (
 	"os"
+	"sync"
 )
 
 const (
@@ -30,7 +31,15 @@ const (
 
 // Watcher is the sshtrustedca event watcher implementation.
 type Watcher struct {
+	// pipePath points to the named pipe it's writing to.
 	pipePath string
+
+	// waitingWrite is a flag to inform the Watcher that the Handler has or
+	// hasn't finished writing.
+	waitingWrite bool
+
+	// mutex protects waitingWrite on concurrent accesses.
+	mutex sync.Mutex
 }
 
 // PipeData wraps the pipe event data.
@@ -38,6 +47,10 @@ type PipeData struct {
 	// File is the writeonly pipe's file descriptor. The user/handler must
 	// make sure to close it after processing the event.
 	File *os.File
+
+	// Finished is a callback used by the event handler to inform the write to
+	// the pipe is finished.
+	Finished func()
 }
 
 // New allocates and initializes a new Watcher.

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca_linux_test.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca_linux_test.go
@@ -87,6 +87,7 @@ func TestPipe(t *testing.T) {
 		if err := pipeData.File.Close(); err != nil {
 			t.Fatalf("Failed to close pipe(write end) file: %+v", err)
 		}
+		pipeData.Finished()
 	}()
 
 	pipeData.File.WriteString(testData)

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -225,7 +225,12 @@ func run(ctx context.Context) {
 
 		// Make sure we close the pipe after we've done writing to it.
 		pipeData := evData.Data.(*sshtrustedca.PipeData)
-		defer pipeData.File.Close()
+		defer func() {
+			if err := pipeData.File.Close(); err != nil {
+				logger.Errorf("Failed to close pipe: %+v", err)
+			}
+			pipeData.Finished()
+		}()
 
 		// The certificates key/endpoint is not cached, we can't rely on the metadata watcher data because of that.
 		certificate, err := mdsClient.GetKey(ctx, "oslogin/certificates", nil)


### PR DESCRIPTION
Avoid trying to re-open the pipe for write until the write is finished. Additionally introduce a channel to communicate the context cancelation handling go routine to finish when returning to the event manager.