### PR TITLE
sshtrustedca: configure selinux context for sshtrustedca pipe

### DIFF
--- a/google_guest_agent/events/events.go
+++ b/google_guest_agent/events/events.go
@@ -97,7 +97,7 @@ type eventBusData struct {
 func init() {
 	err := initWatchers([]Watcher{
 		metadata.New(),
-		sshtrustedca.New(sshtrustedca.DefaultPipePath),
+		sshtrustedca.New(sshtrustedca.DefaultPipePath, true),
 	})
 	if err != nil {
 		logger.Errorf("Failed to initialize watchers: %+v", err)

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca.go
@@ -34,6 +34,10 @@ type Watcher struct {
 	// pipePath points to the named pipe it's writing to.
 	pipePath string
 
+	// configSELinux is a flag used to determine if we should attempt configure SELinux,
+	// tests will want to have it disabled.
+	configSELinux bool
+
 	// waitingWrite is a flag to inform the Watcher that the Handler has or
 	// hasn't finished writing.
 	waitingWrite bool
@@ -54,9 +58,10 @@ type PipeData struct {
 }
 
 // New allocates and initializes a new Watcher.
-func New(pipePath string) *Watcher {
+func New(pipePath string, configSELinux bool) *Watcher {
 	return &Watcher{
-		pipePath: pipePath,
+		pipePath:      pipePath,
+		configSELinux: configSELinux,
 	}
 }
 

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca_linux.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca_linux.go
@@ -18,15 +18,48 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 )
 
+const (
+	// localFileContext is the path to the SELinux' local context matching rules.
+	localFileContext = "/etc/selinux/targeted/contexts/files/file_contexts.local"
+)
+
+// Create selinux file context if not yet set, returns true if restorecon must be executed.
+func configureSELinux(pipePath string) (bool, error) {
+	if _, err := os.Stat(path.Dir(pipePath)); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	data, err := os.ReadFile(localFileContext)
+	if err != nil {
+		return false, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, pipePath) {
+			logger.Debugf("SELinux is configured for sshca pipe: %s", pipePath)
+			return true, nil
+		}
+	}
+
+	conf := fmt.Sprintf("\n%s  -p system_u:object_r:sshd_key_t:s0\n", pipePath)
+	return true, os.WriteFile(localFileContext, []byte(string(data)+conf), 0644)
+}
+
 // Create a named pipe if it doesn't exist.
-func createNamedPipe(pipePath string) error {
+func createNamedPipe(pipePath string, configSELinux bool) error {
 	pipeDir := filepath.Dir(pipePath)
 	_, err := os.Stat(pipeDir)
 
@@ -41,6 +74,23 @@ func createNamedPipe(pipePath string) error {
 		if os.IsNotExist(err) {
 			if err := syscall.Mkfifo(pipePath, 0644); err != nil {
 				return fmt.Errorf("failed to create named pipe: %+v", err)
+			}
+
+			if configSELinux {
+				hasFileContext, err := configureSELinux(pipePath)
+				if err != nil {
+					return fmt.Errorf("failed to configure SELinux: %+v", err)
+				}
+
+				if hasFileContext {
+					// Try to setup selinux context if available.
+					restorecon, err := exec.LookPath("restorecon")
+					if err == nil {
+						if err := exec.Command(restorecon, "-F", pipePath).Run(); err != nil {
+							return fmt.Errorf("failed to setup selinux context: %+v", err)
+						}
+					}
+				}
 			}
 		} else {
 			return fmt.Errorf("failed to stat file: " + pipePath)
@@ -105,7 +155,7 @@ func (mp *Watcher) Run(ctx context.Context, evType string) (bool, interface{}, e
 
 	// If the configured named pipe doesn't exists we create it before emitting events
 	// from it.
-	if err := createNamedPipe(mp.pipePath); err != nil {
+	if err := createNamedPipe(mp.pipePath, mp.configSELinux); err != nil {
 		return true, nil, err
 	}
 

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca_linux_test.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca_linux_test.go
@@ -28,7 +28,7 @@ func TestPipe(t *testing.T) {
 	// Putting a directory name between temp dir and the file name guarantees we test
 	// the directory creation.
 	pipePath := path.Join(t.TempDir(), "ssh", "oslogin_trustedca.pub")
-	watcher := New(pipePath)
+	watcher := New(pipePath, false)
 	testData := "test data transmited through the pipe."
 
 	if watcher.ID() != WatcherID {
@@ -95,7 +95,7 @@ func TestPipe(t *testing.T) {
 
 func TestCancel(t *testing.T) {
 	pipePath := path.Join(t.TempDir(), "ssh", "oslogin_trustedca.pub")
-	watcher := New(pipePath)
+	watcher := New(pipePath, false)
 
 	sync := make(chan bool)
 	defer close(sync)


### PR DESCRIPTION
Make sure we add local selinux file context and apply it to the sshtrustedca pipe.