### PR TITLE
Find previous cert for cleanup using one stored on disk

### DIFF
--- a/google_guest_agent/agentcrypto/crypto_util.go
+++ b/google_guest_agent/agentcrypto/crypto_util.go
@@ -54,6 +54,20 @@ func parsePvtKey(pemKey []byte) (*ecdsa.PrivateKey, error) {
 	return ecKey, nil
 }
 
+// serialNumber reads the certificate from file and returns the serial number in hex.
+func serialNumber(f string) (string, error) {
+	d, err := os.ReadFile(f)
+	if err != nil {
+		return "", fmt.Errorf("unable to read previous client credential file %q: %w", f, err)
+	}
+
+	crt, err := parseCertificate(d)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse certificate at %q: %w", f, err)
+	}
+	return fmt.Sprintf("%x", crt.SerialNumber), nil
+}
+
 // verifySign verifies the client certificate is valid and signed by root CA.
 func verifySign(cert []byte, rootCAFile string) error {
 	caCertPEM, err := os.ReadFile(rootCAFile)
@@ -75,7 +89,7 @@ func verifySign(cert []byte, rootCAFile string) error {
 	}
 
 	if _, err := x509Cert.Verify(opts); err != nil {
-		return fmt.Errorf("failed to verify if client certificate against root CA %q: %w", rootCAFile, err)
+		return fmt.Errorf("failed to verify client certificate against root CA %q: %w", rootCAFile, err)
 	}
 
 	return nil

--- a/google_guest_agent/agentcrypto/mtls_mds.go
+++ b/google_guest_agent/agentcrypto/mtls_mds.go
@@ -148,15 +148,15 @@ func (j *CredsJob) fetchClientCredentials(ctx context.Context, rootCA string) ([
 
 // Run generates the required credentials for MTLS MDS workflow.
 //
-// 1. Fetches, verifies and writes Root CA cert from UEFI variable to /etc/pki/tls/certs/mds/root.crt
-// 2. Fetches encrypted client credentials from MDS, decrypts it via vTPM and writes it to /etc/pki/tls/certs/mds/client.key
+// 1. Fetches, verifies and writes Root CA cert from UEFI variable to /run/google-mds-mtls/root.crt
+// 2. Fetches encrypted client credentials from MDS, decrypts it via vTPM and writes it to /run/google-mds-mtls/client.key
 //
 // Note that these credentials are at `C:\Program Files\Google\Compute Engine\certs\mds` on Windows.
 // Additionally agent also generates a PFX file on windows that can be used invoking HTTPS endpoint.
 //
 // Example usage of these credentials to call HTTPS endpoint of MDS:
 //
-// curl --cacert /etc/pki/tls/certs/mds/root.crt -E /etc/pki/tls/certs/mds/client.key -H "MetadataFlavor: Google" https://169.254.169.254
+// curl --cacert /run/google-mds-mtls/root.crt -E /run/google-mds-mtls/client.key -H "MetadataFlavor: Google" https://169.254.169.254
 //
 // Windows example:
 //
@@ -187,6 +187,7 @@ func (j *CredsJob) Run(ctx context.Context) (bool, error) {
 		return true, fmt.Errorf("failed to store client credentials with an error: %w", err)
 	}
 
+	logger.Infof("Successfully bootstrapped MDS mTLS credentials")
 	return true, nil
 }
 


### PR DESCRIPTION
* Add support for finding a certificate based on issuer name and serial number
* Use that to lookup the certificate stored on disk for cleaning up the previous certificate from certstore