### PR TITLE
snapshot: use main context rather than create its own

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -107,7 +107,7 @@ func agentInit(ctx context.Context) {
 			logger.Infof("Snapshot listener enabled")
 			snapshotServiceIP := config.Section("Snapshots").Key("snapshot_service_ip").MustString("169.254.169.254")
 			snapshotServicePort := config.Section("Snapshots").Key("snapshot_service_port").MustInt(8081)
-			startSnapshotListener(snapshotServiceIP, snapshotServicePort)
+			startSnapshotListener(ctx, snapshotServiceIP, snapshotServicePort)
 		}
 
 		// These scripts are run regardless of metadata/network access and config options.

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -299,8 +299,8 @@ func runCmdOutput(cmd *exec.Cmd) *execResult {
 	return &execResult{code: 0, out: stdout.String()}
 }
 
-func runCmdOutputWithTimeout(timeout time.Duration, name string, args ...string) *execResult {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func runCmdOutputWithTimeout(ctx context.Context, timeout time.Duration, name string, args ...string) *execResult {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	execResult := runCmdOutput(exec.CommandContext(ctx, name, args...))
 	if ctx.Err() != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {


### PR DESCRIPTION
To prevent issues when the process is handling SIGTERM and SINGINT we should be using the main context so it can get "notified" of cancelation etc.