### PR TITLE
run: change all commands to use CommandContext

### DIFF
--- a/google_guest_agent/accounts_unix.go
+++ b/google_guest_agent/accounts_unix.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/user"
@@ -35,19 +36,19 @@ func getUID(path string) string {
 	return ""
 }
 
-func createUser(username, uid string) error {
+func createUser(ctx context.Context, username, uid string) error {
 	useradd := config.Section("Accounts").Key("useradd_cmd").MustString("useradd -m -s /bin/bash -p * {user}")
 	if uid != "" {
 		useradd = fmt.Sprintf("%s -u %s", useradd, uid)
 	}
 	cmd, args := createUserGroupCmd(useradd, username, "")
-	return run.Quiet(cmd, args...)
+	return run.Quiet(ctx, cmd, args...)
 }
 
-func addUserToGroup(user, group string) error {
+func addUserToGroup(ctx context.Context, user, group string) error {
 	gpasswdadd := config.Section("Accounts").Key("gpasswd_add_cmd").MustString("gpasswd -a {user} {group}")
 	cmd, args := createUserGroupCmd(gpasswdadd, user, group)
-	return run.Quiet(cmd, args...)
+	return run.Quiet(ctx, cmd, args...)
 }
 
 func userExists(name string) (bool, error) {

--- a/google_guest_agent/accounts_windows.go
+++ b/google_guest_agent/accounts_windows.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"syscall"
 	"unsafe"
@@ -110,7 +111,7 @@ func resetPwd(username, pwd string) error {
 	return nil
 }
 
-func addUserToGroup(username, group string) error {
+func addUserToGroup(ctx context.Context, username, group string) error {
 	gPtr, err := syscall.UTF16PtrFromString(group)
 	if err != nil {
 		return fmt.Errorf("error encoding group to UTF16: %v", err)
@@ -137,7 +138,7 @@ func addUserToGroup(username, group string) error {
 	return nil
 }
 
-func createUser(username, pwd string) error {
+func createUser(ctx context.Context, username, pwd string) error {
 	uPtr, err := syscall.UTF16PtrFromString(username)
 	if err != nil {
 		return fmt.Errorf("error encoding username to UTF16: %v", err)

--- a/google_guest_agent/clock.go
+++ b/google_guest_agent/clock.go
@@ -39,22 +39,22 @@ func (a *clockskewMgr) disabled(os string) (disabled bool) {
 
 func (a *clockskewMgr) set(ctx context.Context) error {
 	if runtime.GOOS == "freebsd" {
-		err := run.Quiet("service", "ntpd", "status")
+		err := run.Quiet(ctx, "service", "ntpd", "status")
 		if err == nil {
-			if err := run.Quiet("service", "ntpd", "stop"); err != nil {
+			if err := run.Quiet(ctx, "service", "ntpd", "stop"); err != nil {
 				return err
 			}
 			defer func() {
-				if err := run.Quiet("service", "ntpd", "start"); err != nil {
+				if err := run.Quiet(ctx, "service", "ntpd", "start"); err != nil {
 					logger.Warningf("Error starting 'ntpd' after clock sync: %v.", err)
 				}
 			}()
 		}
 		// TODO get server
-		return run.Quiet("ntpdate", "169.254.169.254")
+		return run.Quiet(ctx, "ntpdate", "169.254.169.254")
 	}
 
-	res := run.WithOutput("/sbin/hwclock", "--hctosys", "-u", "--noadjfile")
+	res := run.WithOutput(ctx, "/sbin/hwclock", "--hctosys", "-u", "--noadjfile")
 	if res.ExitCode != 0 || res.StdErr != "" {
 		return error(res)
 	}

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -100,7 +100,7 @@ func agentInit(ctx context.Context) {
 		}
 	} else {
 		// Linux instance setup.
-		defer run.Quiet("systemd-notify", "--ready")
+		defer run.Quiet(ctx, "systemd-notify", "--ready")
 		defer logger.Debugf("notify systemd")
 
 		if config.Section("Snapshots").Key("enabled").MustBool(false) {
@@ -113,7 +113,7 @@ func agentInit(ctx context.Context) {
 		// These scripts are run regardless of metadata/network access and config options.
 		for _, script := range []string{"optimize_local_ssd", "set_multiqueue"} {
 			if config.Section("InstanceSetup").Key(script).MustBool(true) {
-				if err := run.Quiet("google_" + script); err != nil {
+				if err := run.Quiet(ctx, "google_"+script); err != nil {
 					logger.Warningf("Failed to run %q script: %v", "google_"+script, err)
 				}
 			}
@@ -147,7 +147,7 @@ func agentInit(ctx context.Context) {
 		// Disable overcommit accounting; e2 instances only.
 		parts := strings.Split(newMetadata.Instance.MachineType, "/")
 		if strings.HasPrefix(parts[len(parts)-1], "e2-") {
-			if err := run.Quiet("sysctl", "vm.overcommit_memory=1"); err != nil {
+			if err := run.Quiet(ctx, "sysctl", "vm.overcommit_memory=1"); err != nil {
 				logger.Warningf("Failed to run 'sysctl vm.overcommit_memory=1': %v", err)
 			}
 		}
@@ -230,7 +230,7 @@ func generateSSHKeys(ctx context.Context) error {
 	// Generate new keys and upload to guest attributes.
 	for keytype := range keytypes {
 		keyfile := fmt.Sprintf("%s/ssh_host_%s_key", hostKeyDir, keytype)
-		if err := run.Quiet("ssh-keygen", "-t", keytype, "-f", keyfile+".temp", "-N", "", "-q"); err != nil {
+		if err := run.Quiet(ctx, "ssh-keygen", "-t", keytype, "-f", keyfile+".temp", "-N", "", "-q"); err != nil {
 			logger.Warningf("Failed to generate SSH host key %q: %v", keyfile, err)
 			continue
 		}
@@ -263,7 +263,7 @@ func generateSSHKeys(ctx context.Context) error {
 			logger.Warningf("Generated key is malformed, not uploading")
 		}
 	}
-	run.Quiet("restorecon", "-FR", hostKeyDir)
+	run.Quiet(ctx, "restorecon", "-FR", hostKeyDir)
 	return nil
 }
 

--- a/google_guest_agent/stub.go
+++ b/google_guest_agent/stub.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 )
 
@@ -43,10 +44,10 @@ func getWindowsServiceImagePath(regKey string) (string, error) {
 	return "", nil
 }
 
-func getWindowsExeVersion(path string) (versionInfo, error) {
+func getWindowsExeVersion(ctx context.Context, path string) (versionInfo, error) {
 	return versionInfo{0, 0}, nil
 }
 
-func checkWindowsServiceRunning(servicename string) bool {
+func checkWindowsServiceRunning(ctx context.Context, servicename string) bool {
 	return false
 }


### PR DESCRIPTION
With that we can prevent commands taking longer than expected when we are handling context cancellation (i.e. SIGTERM, SIGINT etc).