### PR TITLE
Store certs in ProgramData instead of Program Files

### DIFF
--- a/google_guest_agent/agentcrypto/mtls_mds.go
+++ b/google_guest_agent/agentcrypto/mtls_mds.go
@@ -38,11 +38,6 @@ const (
 	googleGUID = "8be4df61-93ca-11d2-aa0d-00e098032b8c"
 	// googleRootCACertEFIVarName is predefined string part of the UEFI variable name that holds Root CA cert.
 	googleRootCACertEFIVarName = "InstanceRootCACertificate"
-	// rootCACertFileName is the root CA cert.
-	rootCACertFileName = "root.crt"
-	// clientCredsFileName are client credentials, its basically the file
-	// that has the EC private key and the client certificate concatenated.
-	clientCredsFileName = "client.key"
 	// clientCertsKey is the metadata server key at which client identity certificate is exposed.
 	clientCertsKey = "instance/credentials/certs"
 	// MTLSSchedulerID is the identifier used by job scheduler.
@@ -160,7 +155,7 @@ func (j *CredsJob) fetchClientCredentials(ctx context.Context, rootCA string) ([
 //
 // Windows example:
 //
-// $cert = Get-PfxCertificate -FilePath "C:\Program Files\Google\Compute Engine\certs\mds\client.key.pfx"
+// $cert = Get-PfxCertificate -FilePath "C:\ProgramData\Google\Compute Engine\mds-mtls-client.key.pfx"
 // or
 // $cert = Get-ChildItem Cert:\LocalMachine\My | Where-Object { $_.Issuer -like "*google.internal*" }
 // Invoke-RestMethod -Uri https://169.254.169.254 -Method Get -Headers @{"Metadata-Flavor"="Google"} -Certificate $cert

--- a/google_guest_agent/agentcrypto/mtls_mds_linux.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_linux.go
@@ -19,14 +19,19 @@ import "github.com/GoogleCloudPlatform/guest-agent/utils"
 const (
 	// defaultCredsDir is the directory location for MTLS MDS credentials.
 	defaultCredsDir = "/run/google-mds-mtls"
+	// rootCACertFileName is the root CA cert.
+	rootCACertFileName = "root.crt"
+	// clientCredsFileName are client credentials, its basically the file
+	// that has the EC private key and the client certificate concatenated.
+	clientCredsFileName = "client.key"
 )
 
 // writeRootCACert writes Root CA cert from UEFI variable to output file.
 func (j *CredsJob) writeRootCACert(content []byte, outputFile string) error {
-	return utils.WriteFile(content, outputFile)
+	return utils.SaferWriteFile(content, outputFile)
 }
 
 // writeClientCredentials stores client credentials (certificate and private key).
 func (j *CredsJob) writeClientCredentials(plaintext []byte, outputFile string) error {
-	return utils.WriteFile(plaintext, outputFile)
+	return utils.SaferWriteFile(plaintext, outputFile)
 }

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -15,6 +15,8 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -128,5 +130,22 @@ func TestValidateUser(t *testing.T) {
 		if isValid != tt.valid {
 			t.Errorf("ValidateUser(%s) incorrect return: expected: %t - got: %t", tt.user, tt.valid, isValid)
 		}
+	}
+}
+
+func TestSaferWriteFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "file")
+	want := "test-data"
+
+	if err := SaferWriteFile([]byte(want), f); err != nil {
+		t.Errorf("SaferWriteFile(%s, %s) failed unexpectedly with err: %+v", "test-data", f, err)
+	}
+
+	got, err := os.ReadFile(f)
+	if err != nil {
+		t.Errorf("os.ReadFile(%s) failed unexpectedly with err: %+v", f, err)
+	}
+	if string(got) != want {
+		t.Errorf("os.ReadFile(%s) = %s, want %s", f, string(got), want)
 	}
 }


### PR DESCRIPTION
- Store certs in [ProgramData](https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-folderlocations-programdata) at Compute Engine level as any process could access/use it.
- Introduce `SaferWriteFile()`: writes to a temporary file and then replaces the expected output file. This prevents other processes from reading partial content while the writer is still writing.