### PR TITLE
Fix permissions on file created by SaferWriteFile()

### DIFF
--- a/google_guest_agent/agentcrypto/mtls_mds_linux.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_linux.go
@@ -37,7 +37,7 @@ const (
 
 // writeRootCACert writes Root CA cert from UEFI variable to output file.
 func (j *CredsJob) writeRootCACert(ctx context.Context, content []byte, outputFile string) error {
-	if err := utils.SaferWriteFile(content, outputFile); err != nil {
+	if err := utils.SaferWriteFile(content, outputFile, 0644); err != nil {
 		return err
 	}
 
@@ -51,7 +51,7 @@ func (j *CredsJob) writeRootCACert(ctx context.Context, content []byte, outputFi
 
 // writeClientCredentials stores client credentials (certificate and private key).
 func (j *CredsJob) writeClientCredentials(plaintext []byte, outputFile string) error {
-	return utils.SaferWriteFile(plaintext, outputFile)
+	return utils.SaferWriteFile(plaintext, outputFile, 0644)
 }
 
 // getCAStoreUpdater interates over known system trust store updaters and returns the first found.
@@ -100,7 +100,7 @@ func updateSystemStore(ctx context.Context, cert string) error {
 
 	dest := filepath.Join(dir, filepath.Base(cert))
 
-	if err := utils.CopyFile(cert, dest); err != nil {
+	if err := utils.CopyFile(cert, dest, 0644); err != nil {
 		return err
 	}
 

--- a/google_guest_agent/agentcrypto/mtls_mds_windows.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_windows.go
@@ -59,7 +59,7 @@ var (
 
 // writeRootCACert writes Root CA cert from UEFI variable to output file.
 func (j *CredsJob) writeRootCACert(_ context.Context, cacert []byte, outputFile string) error {
-	if err := utils.SaferWriteFile(cacert, outputFile); err != nil {
+	if err := utils.SaferWriteFile(cacert, outputFile, 0644); err != nil {
 		return err
 	}
 
@@ -150,7 +150,7 @@ func (j *CredsJob) writeClientCredentials(creds []byte, outputFile string) error
 		logger.Warningf("Could not get previous serial number, will skip cleanup: %v", err)
 	}
 
-	if err := utils.SaferWriteFile(creds, outputFile); err != nil {
+	if err := utils.SaferWriteFile(creds, outputFile, 0644); err != nil {
 		return fmt.Errorf("failed to write client key: %w", err)
 	}
 
@@ -160,7 +160,7 @@ func (j *CredsJob) writeClientCredentials(creds []byte, outputFile string) error
 	}
 
 	p := filepath.Join(filepath.Dir(outputFile), pfxFile)
-	if err := utils.SaferWriteFile(pfx, p); err != nil {
+	if err := utils.SaferWriteFile(pfx, p, 0644); err != nil {
 		return fmt.Errorf("failed to write PFX file: %w", err)
 	}
 

--- a/utils/main.go
+++ b/utils/main.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -165,20 +166,20 @@ func (s *SerialPort) Write(b []byte) (int, error) {
 }
 
 // WriteFile creates parent directories if required and writes content to the output file.
-func WriteFile(content []byte, outputFile string) error {
-	if err := os.MkdirAll(filepath.Dir(outputFile), 0644); err != nil {
+func WriteFile(content []byte, outputFile string, perm fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(outputFile), perm); err != nil {
 		return fmt.Errorf("unable to create required directories for %q: %w", outputFile, err)
 	}
-	return os.WriteFile(outputFile, content, 0644)
+	return os.WriteFile(outputFile, content, perm)
 }
 
 // SaferWriteFile writes to a temporary file and then replaces the expected output file.
 // This prevents other processes from reading partial content while the writer is still writing.
-func SaferWriteFile(content []byte, outputFile string) error {
+func SaferWriteFile(content []byte, outputFile string, perm fs.FileMode) error {
 	dir := filepath.Dir(outputFile)
 	name := filepath.Base(outputFile)
 
-	if err := os.MkdirAll(dir, 0644); err != nil {
+	if err := os.MkdirAll(dir, perm); err != nil {
 		return fmt.Errorf("unable to create required directories %q: %w", dir, err)
 	}
 
@@ -187,23 +188,35 @@ func SaferWriteFile(content []byte, outputFile string) error {
 		return fmt.Errorf("unable to create temporary file under %q: %w", dir, err)
 	}
 
+	if err := os.Chmod(tmp.Name(), perm); err != nil {
+		return fmt.Errorf("unable to set permissions on temporary file %q: %w", dir, err)
+	}
+
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("failed to close temporary file: %w", err)
 	}
 
-	if err := WriteFile(content, tmp.Name()); err != nil {
+	if err := WriteFile(content, tmp.Name(), perm); err != nil {
 		return fmt.Errorf("unable to write to a temporary file %q: %w", tmp.Name(), err)
 	}
 
 	return os.Rename(tmp.Name(), outputFile)
 }
 
-// CopyFile copies content from src to dst.
-func CopyFile(src, dst string) error {
+// CopyFile copies content from src to dst and sets permissions.
+func CopyFile(src, dst string, perm fs.FileMode) error {
 	b, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("failed to read %q: %w", src, err)
 	}
 
-	return WriteFile(b, dst)
+	if err := WriteFile(b, dst, perm); err != nil {
+		return fmt.Errorf("failed to write %q: %w", dst, err)
+	}
+
+	if err := os.Chmod(dst, perm); err != nil {
+		return fmt.Errorf("unable to set permissions on destination file %q: %w", dst, err)
+	}
+
+	return nil
 }

--- a/utils/main_test.go
+++ b/utils/main_test.go
@@ -137,7 +137,7 @@ func TestSaferWriteFile(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "file")
 	want := "test-data"
 
-	if err := SaferWriteFile([]byte(want), f); err != nil {
+	if err := SaferWriteFile([]byte(want), f, 0644); err != nil {
 		t.Errorf("SaferWriteFile(%s, %s) failed unexpectedly with err: %+v", "test-data", f, err)
 	}
 
@@ -147,6 +147,15 @@ func TestSaferWriteFile(t *testing.T) {
 	}
 	if string(got) != want {
 		t.Errorf("os.ReadFile(%s) = %s, want %s", f, string(got), want)
+	}
+
+	i, err := os.Stat(f)
+	if err != nil {
+		t.Errorf("os.Stat(%s) failed unexpectedly with err: %+v", f, err)
+	}
+
+	if i.Mode().Perm() != 0o644 {
+		t.Errorf("SaferWriteFile(%s) set incorrect permissions, os.Stat(%s) = %o, want %o", f, f, i.Mode().Perm(), 0o644)
 	}
 }
 
@@ -158,7 +167,7 @@ func TestCopyFile(t *testing.T) {
 	if err := os.WriteFile(src, []byte(want), 0777); err != nil {
 		t.Fatalf("failed to write test source file: %v", err)
 	}
-	if err := CopyFile(src, dst); err != nil {
+	if err := CopyFile(src, dst, 0644); err != nil {
 		t.Errorf("CopyFile(%s, %s) failed unexpectedly with error: %v", src, dst, err)
 	}
 
@@ -169,6 +178,15 @@ func TestCopyFile(t *testing.T) {
 	if string(got) != want {
 		t.Errorf("CopyFile(%s, %s) copied %q, expected %q", src, dst, string(got), want)
 	}
+
+	i, err := os.Stat(dst)
+	if err != nil {
+		t.Errorf("os.Stat(%s) failed unexpectedly with err: %+v", dst, err)
+	}
+
+	if i.Mode().Perm() != 0o644 {
+		t.Errorf("SaferWriteFile(%s) set incorrect permissions, os.Stat(%s) = %o, want %o", dst, dst, i.Mode().Perm(), 0o644)
+	}
 }
 
 func TestCopyFileError(t *testing.T) {
@@ -176,7 +194,7 @@ func TestCopyFileError(t *testing.T) {
 	dst := filepath.Join(tmp, "dst")
 	src := filepath.Join(tmp, "src")
 
-	if err := CopyFile(src, dst); err == nil {
+	if err := CopyFile(src, dst, 0644); err == nil {
 		t.Errorf("CopyFile(%s, %s) succeeded for non-existent file, want error", src, dst)
 	}
 }


### PR DESCRIPTION
Temporary files are created with permission `600`