### PR TITLE
Add support for the SSH key options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/kardianos/service v1.2.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
+	golang.org/x/crypto v0.11.0
 	golang.org/x/sys v0.11.0
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
@@ -39,7 +40,6 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,7 @@ golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.10.0 h1:3R7pNqamzBraeqj/Tj8qt1aQ2HpmlC+Cx/qL/7hn4/c=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/google_authorized_keys/main_test.go
+++ b/google_authorized_keys/main_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/guest-agent/metadata"
+	"github.com/GoogleCloudPlatform/guest-agent/utils"
 )
 
 func stringSliceEqual(a, b []string) bool {
@@ -50,16 +51,20 @@ var truebool *bool = &t
 var falsebool *bool = &f
 
 func TestParseSSHKeys(t *testing.T) {
+	pubKeyA := utils.MakeRandRSAPubKey(t)
+	pubKeyB := utils.MakeRandRSAPubKey(t)
+	pubKey := utils.MakeRandRSAPubKey(t)
+
 	keys := []string{
 		"# Here is some random data in the file.",
-		"usera:ssh-rsa AAAA1234USERA",
-		"userb:ssh-rsa AAAA1234USERB",
-		`usera:ssh-rsa AAAA1234 google-ssh {"userName":"usera@example.com","expireOn":"2095-04-23T12:34:56+0000"}`,
-		`usera:ssh-rsa AAAA1234 google-ssh {"userName":"usera@example.com","expireOn":"2020-04-23T12:34:56+0000"}`,
+		fmt.Sprintf("usera:ssh-rsa %s", pubKeyA),
+		fmt.Sprintf("userb:ssh-rsa %s", pubKeyB),
+		fmt.Sprintf(`usera:ssh-rsa %s google-ssh {"userName":"usera@example.com","expireOn":"2095-04-23T12:34:56+0000"}`, pubKey),
+		fmt.Sprintf(`usera:ssh-rsa %s google-ssh {"userName":"usera@example.com","expireOn":"2020-04-23T12:34:56+0000"}`, pubKey),
 	}
 	expected := []string{
-		"ssh-rsa AAAA1234USERA",
-		`ssh-rsa AAAA1234 google-ssh {"userName":"usera@example.com","expireOn":"2095-04-23T12:34:56+0000"}`,
+		fmt.Sprintf("ssh-rsa %s", pubKeyA),
+		fmt.Sprintf(`ssh-rsa %s google-ssh {"userName":"usera@example.com","expireOn":"2095-04-23T12:34:56+0000"}`, pubKey),
 	}
 
 	user := "usera"
@@ -117,6 +122,8 @@ func TestCheckWinSSHEnabled(t *testing.T) {
 }
 
 func TestGetUserKeysNew(t *testing.T) {
+	pubKey := utils.MakeRandRSAPubKey(t)
+
 	tests := []struct {
 		userName         string
 		instanceMetadata attributes
@@ -125,50 +132,77 @@ func TestGetUserKeysNew(t *testing.T) {
 	}{
 		{
 			userName: "name",
-			instanceMetadata: attributes{BlockProjectSSHKeys: false,
-				SSHKeys: []string{"name:ssh-rsa [KEY] instance1", "othername:ssh-rsa [KEY] instance2"},
+			instanceMetadata: attributes{
+				BlockProjectSSHKeys: false,
+				SSHKeys: []string{
+					fmt.Sprintf("name:ssh-rsa %s instance1", pubKey),
+					fmt.Sprintf("othername:ssh-rsa %s instance2", pubKey),
+				},
 			},
 			projectMetadata: attributes{
-				SSHKeys: []string{"name:ssh-rsa [KEY] project1", "othername:ssh-rsa [KEY] project2"},
+				SSHKeys: []string{
+					fmt.Sprintf("name:ssh-rsa %s project1", pubKey),
+					fmt.Sprintf("othername:ssh-rsa %s project2", pubKey),
+				},
 			},
-			expectedKeys: []string{"ssh-rsa [KEY] instance1", "ssh-rsa [KEY] project1"},
+			expectedKeys: []string{
+				fmt.Sprintf("ssh-rsa %s instance1", pubKey),
+				fmt.Sprintf("ssh-rsa %s project1", pubKey),
+			},
 		},
 		{
 			userName: "name",
-			instanceMetadata: attributes{BlockProjectSSHKeys: true,
-				SSHKeys: []string{"name:ssh-rsa [KEY] instance1", "othername:ssh-rsa [KEY] instance2"},
+			instanceMetadata: attributes{
+				BlockProjectSSHKeys: true,
+				SSHKeys: []string{
+					fmt.Sprintf("name:ssh-rsa %s instance1", pubKey),
+					fmt.Sprintf("othername:ssh-rsa %s instance2", pubKey),
+				},
 			},
 			projectMetadata: attributes{
-				SSHKeys: []string{"name:ssh-rsa [KEY] project1", "othername:ssh-rsa [KEY] project2"},
+				SSHKeys: []string{
+					fmt.Sprintf("name:ssh-rsa %s project1", pubKey),
+					fmt.Sprintf("othername:ssh-rsa %s project2", pubKey),
+				},
 			},
-			expectedKeys: []string{"ssh-rsa [KEY] instance1"},
+			expectedKeys: []string{fmt.Sprintf("ssh-rsa %s instance1", pubKey)},
 		},
 		{
 			userName: "name",
-			instanceMetadata: attributes{BlockProjectSSHKeys: false,
-				SSHKeys: []string{"name:ssh-rsa [KEY] instance1", "othername:ssh-rsa [KEY] instance2"},
+			instanceMetadata: attributes{
+				BlockProjectSSHKeys: false,
+				SSHKeys: []string{
+					fmt.Sprintf("name:ssh-rsa %s instance1", pubKey),
+					fmt.Sprintf("othername:ssh-rsa %s instance2", pubKey),
+				},
 			},
 			projectMetadata: attributes{
 				SSHKeys: nil,
 			},
-			expectedKeys: []string{"ssh-rsa [KEY] instance1"},
+			expectedKeys: []string{fmt.Sprintf("ssh-rsa %s instance1", pubKey)},
 		},
 		{
 			userName: "name",
-			instanceMetadata: attributes{BlockProjectSSHKeys: false,
-				SSHKeys: nil,
+			instanceMetadata: attributes{
+				BlockProjectSSHKeys: false,
+				SSHKeys:             nil,
 			},
 			projectMetadata: attributes{
-				SSHKeys: []string{"name:ssh-rsa [KEY] project1", "othername:ssh-rsa [KEY] project2"},
+				SSHKeys: []string{
+					fmt.Sprintf("name:ssh-rsa %s project1", pubKey),
+					fmt.Sprintf("othername:ssh-rsa %s project2", pubKey),
+				},
 			},
-			expectedKeys: []string{"ssh-rsa [KEY] project1"},
+			expectedKeys: []string{fmt.Sprintf("ssh-rsa %s project1", pubKey)},
 		},
 	}
 
 	for count, tt := range tests {
-		if got, want := getUserKeys(tt.userName, &tt.instanceMetadata, &tt.projectMetadata), tt.expectedKeys; !stringSliceEqual(got, want) {
-			t.Errorf("getUserKeys[%d] incorrect return: got %v, want %v", count, got, want)
-		}
+		t.Run(fmt.Sprintf("test-%d", count), func(t *testing.T) {
+			if got, want := getUserKeys(tt.userName, &tt.instanceMetadata, &tt.projectMetadata), tt.expectedKeys; !stringSliceEqual(got, want) {
+				t.Errorf("getUserKeys[%d] incorrect return: got %v, want %v", count, got, want)
+			}
+		})
 	}
 }
 

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -202,6 +202,7 @@ var badSSHKeys []string
 // user:ssh-rsa [KEY_VALUE] [USERNAME]
 // user:ssh-rsa [KEY_VALUE]
 // user:ssh-rsa [KEY_VALUE] google-ssh {"userName":"[USERNAME]","expireOn":"[EXPIRE_TIME]"}
+// user:[KEY_OPTIONS] ssh-rsa [KEY_VALUE]
 func getUserKeys(mdkeys []string) map[string][]string {
 	mdKeyMap := make(map[string][]string)
 	for i := 0; i < len(mdkeys); i++ {

--- a/google_guest_agent/windows_accounts_test.go
+++ b/google_guest_agent/windows_accounts_test.go
@@ -22,9 +22,11 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
+	"fmt"
 	"hash"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 	"unicode"
@@ -232,41 +234,43 @@ func TestCompareAccounts(t *testing.T) {
 }
 
 func TestGetUserKeys(t *testing.T) {
+	pubKey := utils.MakeRandRSAPubKey(t)
+
 	var tests = []struct {
 		key           string
 		expectedValid int
 	}{
-		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0000"}`,
+		{fmt.Sprintf(`user:ssh-rsa %s google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0000"}`, pubKey),
 			1,
 		},
-		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0700"}`,
+		{fmt.Sprintf(`user:ssh-rsa %s google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0700"}`, pubKey),
 			1,
 		},
-		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0700", "futureField": "UNUSED_FIELDS_IGNORED"}`,
+		{fmt.Sprintf(`user:ssh-rsa %s google-ssh {"userName":"user@email.com", "expireOn":"2028-11-08T19:30:47+0700", "futureField": "UNUSED_FIELDS_IGNORED"}`, pubKey),
 			1,
 		},
-		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2018-11-08T19:30:46+0000"}`,
+		{fmt.Sprintf(`user:ssh-rsa %s google-ssh {"userName":"user@email.com", "expireOn":"2018-11-08T19:30:46+0000"}`, pubKey),
 			0,
 		},
-		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"2018-11-08T19:30:46+0700"}`,
+		{fmt.Sprintf(`user:ssh-rsa %s google-ssh {"userName":"user@email.com", "expireOn":"2018-11-08T19:30:46+0700"}`, pubKey),
 			0,
 		},
-		{`user:ssh-rsa [KEY] google-ssh {"userName":"user@email.com", "expireOn":"INVALID_TIMESTAMP"}`,
+		{fmt.Sprintf(`user:ssh-rsa %s google-ssh {"userName":"user@email.com", "expireOn":"INVALID_TIMESTAMP"}`, pubKey),
 			0,
 		},
-		{`user:ssh-rsa [KEY] google-ssh`,
+		{fmt.Sprintf(`user:ssh-rsa %s google-ssh`, pubKey),
 			0,
 		},
-		{`user:ssh-rsa [KEY] user`,
+		{fmt.Sprintf(`user:ssh-rsa %s user`, pubKey),
 			1,
 		},
-		{`user:ssh-rsa [KEY]`,
+		{fmt.Sprintf(`user:ssh-rsa %s`, pubKey),
 			1,
 		},
-		{`malformed-ssh-keys [KEY] google-ssh`,
+		{fmt.Sprintf(`malformed-ssh-keys %s google-ssh`, pubKey),
 			0,
 		},
-		{`:malformed-ssh-keys [KEY] google-ssh`,
+		{fmt.Sprintf(`:malformed-ssh-keys %s google-ssh`, pubKey),
 			0,
 		},
 	}
@@ -280,6 +284,8 @@ func TestGetUserKeys(t *testing.T) {
 }
 
 func TestRemoveExpiredKeys(t *testing.T) {
+	randKey := utils.MakeRandRSAPubKey(t)
+
 	var tests = []struct {
 		key   string
 		valid bool
@@ -307,14 +313,15 @@ func TestRemoveExpiredKeys(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ret := removeExpiredKeys([]string{tt.key})
+		currentKey := strings.Replace(tt.key, "[KEY]", randKey, 1)
+		ret := removeExpiredKeys([]string{currentKey})
 		if tt.valid {
-			if len(ret) == 0 || ret[0] != tt.key {
-				t.Errorf("valid key was removed: %q", tt.key)
+			if len(ret) == 0 || ret[0] != currentKey {
+				t.Errorf("valid key was removed: %q", currentKey)
 			}
 		}
 		if !tt.valid && len(ret) == 1 {
-			t.Errorf("invalid key was kept: %q", tt.key)
+			t.Errorf("invalid key was kept: %q", currentKey)
 		}
 	}
 }

--- a/utils/test.go
+++ b/utils/test.go
@@ -1,0 +1,38 @@
+//  Copyright 2023 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package utils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// MakeRandRSAPubKey generates base64 encoded 256 bit RSA public key for use in tests.
+func MakeRandRSAPubKey(t *testing.T) string {
+	t.Helper()
+	prv, err := rsa.GenerateKey(rand.Reader, 256)
+	if err != nil {
+		t.Fatalf("error generating RSA key: %v", err)
+	}
+	sshPublic, err := ssh.NewPublicKey(prv.Public())
+	if err != nil {
+		t.Fatalf("error wrapping ssh public key: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(sshPublic.Marshal())
+}


### PR DESCRIPTION
SSH Key options as defined by the spec:
https://man.openbsd.org/sshd.8#agent-forwarding

For instance they allow authorized SSH Key to look something like:

```
restrict,command="echo hi" ssh-rsa [KEY_MATERIAL] [COMMENT]
```

To enable this:
- Switch function that parses the key from parsing by space to usage of ssh.ParseAuthorizedKey
- Add more tests that cover the new use case
- Fix all existing tests to have a valid rsa key material