### PR TITLE
gitignore: unify ignore in the root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-google_guest_agent/google_guest_agent
+# ignore all built binaries
+**/gce_workload_cert_refresh
+**/google_authorized_keys
+**/google_guest_agent
+**/google_metadata_script_runner

--- a/google_guest_agent/.gitignore
+++ b/google_guest_agent/.gitignore
@@ -1,1 +1,0 @@
-google_guest_agent.exe


### PR DESCRIPTION
Removes the google_guest_agent's own ignore file and add entries for all binaries.