### PR TITLE
oslogin: introduce a feature flag to cert auth

### DIFF
--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -84,6 +84,9 @@ dhcp_command =
 ip_forwarding = true
 setup = true
 
+[OSLogin]
+cert_authentication = true
+
 [Snapshots]
 enabled = false
 snapshot_service_ip = 169.254.169.254
@@ -138,6 +141,9 @@ type Sections struct {
 	// NetworkInterfaces defines if the network interfaces should be managed/configured by guest-agent
 	// as well as the commands definitions for network configuration.
 	NetworkInterfaces *NetworkInterfaces `ini:"NetworkInterfaces,omitempty"`
+
+	// OSLogin defines the OS Login configuration options.
+	OSLogin *OSLogin `ini:"OSLogin,omitempty"`
 
 	// Snpashots defines the snapshot listener configuration and behavior i.e. the server address and port.
 	Snapshots *Snapshots `ini:"Snapshots,omitempty"`
@@ -225,6 +231,11 @@ type MetadataScripts struct {
 	Startup           bool   `ini:"startup,omitempty"`
 	StartupWindows    bool   `ini:"startup-windows,omitempty"`
 	SysprepSpecialize bool   `ini:"sysprep_specialize,omitempty"`
+}
+
+// OSLogin contains the configurations of OSLogin section.
+type OSLogin struct {
+	CertAuthentication bool `ini:"cert_authentication,omitempty"`
 }
 
 // NetworkInterfaces contains the configurations of NetworkInterfaces section.

--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -208,10 +208,10 @@ func updateSSHConfig(sshConfig string, enable, twofactor, pamlessAuthStack, skey
 		}
 	}
 	authorizedKeysUser := "AuthorizedKeysCommandUser root"
+
+	// Certificate based authentication.
 	authorizedPrincipalsCommand := "AuthorizedPrincipalsCommand /usr/bin/google_authorized_principals %u %k"
 	authorizedPrincipalsUser := "AuthorizedPrincipalsCommandUser root"
-
-	// TODO: only enable this key configuration if certs mechanism is enabled
 	trustedUserCAKeys := "TrustedUserCAKeys " + sshtrustedca.DefaultPipePath
 
 	twoFactorAuthMethods := "AuthenticationMethods publickey,keyboard-interactive"
@@ -225,8 +225,13 @@ func updateSSHConfig(sshConfig string, enable, twofactor, pamlessAuthStack, skey
 	filtered := filterGoogleLines(string(sshConfig))
 
 	if enable {
-		osLoginBlock := []string{googleBlockStart, authorizedKeysCommand, authorizedKeysUser, trustedUserCAKeys}
-		if pamlessAuthStack {
+		osLoginBlock := []string{googleBlockStart, authorizedKeysCommand, authorizedKeysUser}
+
+		if cfg.Get().OSLogin.CertAuthentication {
+			osLoginBlock = append(osLoginBlock, trustedUserCAKeys)
+		}
+
+		if pamlessAuthStack && cfg.Get().OSLogin.CertAuthentication {
 			osLoginBlock = append(osLoginBlock, authorizedPrincipalsCommand, authorizedPrincipalsUser)
 		}
 

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events/sshtrustedca"
 	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 )
@@ -308,6 +309,10 @@ func TestUpdateSSHConfig(t *testing.T) {
 			twofactor: false,
 			skey:      true,
 		},
+	}
+
+	if err := cfg.Load(nil); err != nil {
+		t.Fatalf("Failed to initialize configuration manager: %+v", err)
 	}
 
 	for idx, tt := range tests {

--- a/instance_configs.cfg
+++ b/instance_configs.cfg
@@ -36,3 +36,6 @@ dhclient_script = /sbin/google-dhclient-script
 dhcp_command = 
 ip_forwarding = true
 setup = true
+
+[OSLogin]
+cert_authentication = true


### PR DESCRIPTION
With this flag customers can choose to disable the configuration management for OS Login cert based authentication.