### PR TITLE
oslogin: resort ssh configuration keys

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -225,7 +225,7 @@ func updateSSHConfig(sshConfig string, enable, twofactor, pamlessAuthStack, skey
 	filtered := filterGoogleLines(string(sshConfig))
 
 	if enable {
-		osLoginBlock := []string{googleBlockStart, authorizedKeysCommand, authorizedKeysUser}
+		osLoginBlock := []string{googleBlockStart}
 
 		if cfg.Get().OSLogin.CertAuthentication {
 			osLoginBlock = append(osLoginBlock, trustedUserCAKeys)
@@ -234,6 +234,8 @@ func updateSSHConfig(sshConfig string, enable, twofactor, pamlessAuthStack, skey
 		if pamlessAuthStack && cfg.Get().OSLogin.CertAuthentication {
 			osLoginBlock = append(osLoginBlock, authorizedPrincipalsCommand, authorizedPrincipalsUser)
 		}
+
+		osLoginBlock = append(osLoginBlock, authorizedKeysCommand, authorizedKeysUser)
 
 		if twofactor {
 			osLoginBlock = append(osLoginBlock, twoFactorAuthMethods, challengeResponseEnable)

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -208,9 +208,9 @@ func TestUpdateSSHConfig(t *testing.T) {
 			},
 			want: []string{
 				googleBlockStart,
+				trustedUserCAKeys,
 				authorizedKeysCommand,
 				authorizedKeysUser,
-				trustedUserCAKeys,
 				twoFactorAuthMethods,
 				challengeResponseEnable,
 				googleBlockEnd,
@@ -234,9 +234,9 @@ func TestUpdateSSHConfig(t *testing.T) {
 			},
 			want: []string{
 				googleBlockStart,
+				trustedUserCAKeys,
 				authorizedKeysCommand,
 				authorizedKeysUser,
-				trustedUserCAKeys,
 				twoFactorAuthMethods,
 				challengeResponseEnable,
 				googleBlockEnd,
@@ -259,9 +259,9 @@ func TestUpdateSSHConfig(t *testing.T) {
 			},
 			want: []string{
 				googleBlockStart,
+				trustedUserCAKeys,
 				authorizedKeysCommand,
 				authorizedKeysUser,
-				trustedUserCAKeys,
 				googleBlockEnd,
 				"line1",
 				"line2",
@@ -298,9 +298,9 @@ func TestUpdateSSHConfig(t *testing.T) {
 			},
 			want: []string{
 				googleBlockStart,
+				trustedUserCAKeys,
 				authorizedKeysCommandSk,
 				authorizedKeysUser,
-				trustedUserCAKeys,
 				googleBlockEnd,
 				"line1",
 				"line2",


### PR DESCRIPTION
Debian 12 doesn't like to have AuthorizedPrincipalsCommand{User} after AuthorizedKeysCommand{User}, this change makes sure the principals one shows up first.