### PR TITLE
Disable the IO scheduler based on metadata.

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -137,11 +137,6 @@ func agentInit(ctx context.Context) {
 		// boot. If this changes, we will hook these to an explicit
 		// on-boot signal.
 
-		logger.Debugf("set IO scheduler config")
-		if err := setIOScheduler(); err != nil {
-			logger.Warningf("Failed to set IO scheduler: %v", err)
-		}
-
 		// Allow users to opt out of below instance setup actions.
 		if !config.InstanceSetup.NetworkEnabled {
 			logger.Infof("InstanceSetup.network_enabled is false, skipping setup actions that require metadata")
@@ -155,6 +150,13 @@ func agentInit(ctx context.Context) {
 		for newMetadata == nil {
 			logger.Debugf("populate first time metadata...")
 			newMetadata, _ = mdsClient.Get(ctx)
+		}
+
+		if !newMetadata.Instance.Attributes.DisableIOScheduler {
+			logger.Debugf("set IO scheduler config")
+			if err := setIOScheduler(); err != nil {
+				logger.Warningf("Failed to set IO scheduler: %v", err)
+			}
 		}
 
 		// Disable overcommit accounting; e2 instances only.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -174,6 +174,7 @@ type Attributes struct {
 	WSFCAddresses         string
 	WSFCAgentPort         string
 	DisableTelemetry      bool
+	DisableIOScheduler    bool
 }
 
 // UnmarshalJSON unmarshals b into Attribute.
@@ -201,6 +202,7 @@ func (a *Attributes) UnmarshalJSON(b []byte) error {
 		WSFCAddresses         string      `json:"wsfc-addrs"`
 		WSFCAgentPort         string      `json:"wsfc-agent-port"`
 		DisableTelemetry      string      `json:"disable-guest-telemetry"`
+		DisableIOScheduler    string      `json:"disable-io-scheduler"`
 	}
 	var temp inner
 	if err := json.Unmarshal(b, &temp); err != nil {
@@ -250,6 +252,10 @@ func (a *Attributes) UnmarshalJSON(b []byte) error {
 	value, err = strconv.ParseBool(temp.DisableTelemetry)
 	if err == nil {
 		a.DisableTelemetry = value
+	}
+	value, err = strconv.ParseBool(temp.DisableIOScheduler)
+	if err == nil {
+		a.DisableIOScheduler = value
 	}
 	// So SSHKeys will be nil instead of []string{}
 	if temp.SSHKeys != "" {


### PR DESCRIPTION
Because the google_guest_agent runs after udev rules, it overrides them, preventing the user from having any way to override the defaults, the way they might wish.

This disables that behavior allowing the "normal" way of setting the io scheduler to work, udev rules, etc.  With no concerns that GCP will come back and reset the scheduler.