### PR TITLE
oslogin: declare explicitly dependency

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9.20160709), dh-golang (>= 1.1), golang-go
 
 Package: google-guest-agent
 Architecture: any
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, google-compute-engine-oslogin (>= 20231003.00)
 Conflicts: python-google-compute-engine, python3-google-compute-engine
 Description: Google Compute Engine Guest Agent
  Contains the guest agent and metadata script runner binaries.

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -23,6 +23,7 @@ Summary: Google Compute Engine guest agent.
 License: ASL 2.0
 Url: https://cloud.google.com/compute/docs/images/guest-environment
 Source0: %{name}_%{version}.orig.tar.gz
+Requires: google-compute-engine-oslogin >= 20231003.00
 
 BuildArch: %{_arch}
 %if ! 0%{?el6}


### PR DESCRIPTION
The cert based authentication has a inner dependency of a specific version of guest-oslogin (or higher) so set it explicitly and make sure both packages move together.