### PR TITLE
docs update: add configuration and event manager's docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ MetadataScripts   | shutdown               | `false` disables shutdown script ex
 NetworkInterfaces | setup                  | `false` skips network interface setup.
 NetworkInterfaces | ip\_forwarding         | `false` skips IP forwarding.
 NetworkInterfaces | dhcp\_command          | String path for alternate dhcp executable used to enable network interfaces.
+OSLogin           | cert_authentication    | `false` prevents guest-agent from setting up sshd's `TrustedUserCAKeys`, `AuthorizedPrincipalsCommand` and `AuthorizedPrincipalsCommandUser` configuration keys. Default value: `true`.
 
 Setting `network_enabled` to `false` will disable generating host keys and the
 `boto` config in the guest.

--- a/google_guest_agent/events/Readme.md
+++ b/google_guest_agent/events/Readme.md
@@ -72,3 +72,4 @@ Below is a high level sequence diagram showing how the **Guest Agent**, **Manage
 |Watcher|Events|Desc|
 |-------|------|----|
 |metadata|metadata-watcher,longpoll|A new version of the metadata descriptor was detected.|
+|ssh-trusted-ca-pipe-watcher|ssh-trusted-ca-pipe-watcher,read|A read in the trusted-ca pipe was detected.|


### PR DESCRIPTION
Document the new OSLogin.cert_authentication configuration key and adds the trusted-ca's event's to the list of supported event watchers.