### PR TITLE
Schedule MTLS job before notifying systemd

### DIFF
--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/agentcrypto"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events"
 	mdsEvent "github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events/metadata"
@@ -200,11 +199,6 @@ func runAgent(ctx context.Context) {
 	// knownJobs is list of default jobs that run on a pre-defined schedule.
 	knownJobs := []scheduler.Job{telemetry.New(mdsClient, programName, version)}
 	scheduler.ScheduleJobs(ctx, knownJobs, false)
-
-	// Schedules jobs that need to be started before notifying systemd Agent process has started.
-	if cfg.Get().Unstable.MDSMTLS {
-		scheduler.ScheduleJobs(ctx, []scheduler.Job{agentcrypto.New()}, true)
-	}
 
 	eventsConfig := &events.Config{
 		Watchers: []string{


### PR DESCRIPTION
Schedule mTLS job before notifying systemd. This will allow any process in the Guest to take a dependency on Guest Agent and ensure credentials are available for use on startup.