### PR TITLE
instance setup: trust/rely on metadata package's retry

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -150,13 +150,14 @@ func agentInit(ctx context.Context) {
 			return
 		}
 
-		// The below actions require metadata to be set, so if it
-		// hasn't yet been set, wait on it here. In instances without
-		// network access, this will become an indefinite wait.
-		// TODO: split agentInit into needs-network and no-network functions.
-		for newMetadata == nil {
-			logger.Debugf("populate first time metadata...")
-			newMetadata, _ = mdsClient.Get(ctx)
+		if newMetadata == nil {
+			var err error
+			logger.Debugf("populate metadata for the first time...")
+			newMetadata, err = mdsClient.Get(ctx)
+			if err != nil {
+				logger.Errorf("Failed to reach MDS(all retries exhausted): %+v", err)
+				os.Exit(1)
+			}
 		}
 
 		// Disable overcommit accounting; e2 instances only.


### PR DESCRIPTION
With this infinite retry we'll fail to handle SIG ABORT. If the network/MDS is unreachable and a reboot is done guest agent will only finish after the systemd unit's timeout is reached and then systemd does a SIG KILL - the MDS package will fail since the context is canceled and return error, but this loop is ignoring the error and will keep retrying.

This PR changes the behavior and relies on the metadata package's retry strategy.