### PR TITLE
Add the ability to manage OS hostname and the hosts file to the guest-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The guest agent will perform some actions one time only, on the first VM boot:
 #### Telemetry
 
 The guest agent will record some basic system telemetry information at start and
-then once every 24 hours. 
+then once every 24 hours.
 
 *   Guest agent version and architecture
 *   Operating system name and version
@@ -210,6 +210,10 @@ NetworkInterfaces | setup                  | `false` skips network interface set
 NetworkInterfaces | ip\_forwarding         | `false` skips IP forwarding.
 NetworkInterfaces | dhcp\_command          | String path for alternate dhcp executable used to enable network interfaces.
 OSLogin           | cert_authentication    | `false` prevents guest-agent from setting up sshd's `TrustedUserCAKeys`, `AuthorizedPrincipalsCommand` and `AuthorizedPrincipalsCommandUser` configuration keys. Default value: `true`.
+Unstable          | set\_hostname          | `false` disables setting the hostname.
+Unstable          | fqdn\_as\_hostname     | Toggle setting the hostname to the FQDN, instead of the first section.
+Unstable          | set\_fqdn              | `false` disables managing the hosts file to make FQDNs resolve to the assigned GCE IP addresses.
+Unstable          | additional\_aliases    | Comma separated list of aliases to append to the GCE entries in the hosts file.
 
 Setting `network_enabled` to `false` will disable generating host keys and the
 `boto` config in the guest.

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	cloud.google.com/go/iam v1.1.1 // indirect
 	cloud.google.com/go/logging v1.7.0 // indirect
 	cloud.google.com/go/longrunning v0.5.1 // indirect
+	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/google/go-sev-guest v0.7.0 // indirect
 	github.com/google/logger v1.1.1 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect

--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -7,7 +7,7 @@ Before=sshd.service
 #   SLES/EL7: network.service (SLES via wicked.service)
 #   EL8: NetworkManager.service
 #   COS/Ubuntu 18.04+: systemd-networkd.service
-After=network-online.target syslog.service
+After=network-online.target syslog.service systemd-hostnamed.service
 After=network.service networking.service NetworkManager.service systemd-networkd.service
 Wants=network-online.target
 PartOf=network.service networking.service NetworkManager.service systemd-networkd.service

--- a/google_guest_agent/agentcrypto/mtls_mds_linux.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_linux.go
@@ -55,7 +55,7 @@ func (j *CredsJob) writeRootCACert(ctx context.Context, content []byte, outputFi
 	if err := os.MkdirAll(filepath.Dir(outputFile), 0655); err != nil {
 		return err
 	}
-	if err := utils.SaferWriteFile(content, outputFile, 0644, -1, -1); err != nil {
+	if err := utils.SaferWriteFile(content, outputFile, utils.FileOptions{Perm: 0644}); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (j *CredsJob) writeClientCredentials(plaintext []byte, outputFile string) e
 	if err := os.MkdirAll(filepath.Dir(outputFile), 0655); err != nil {
 		return err
 	}
-	return utils.SaferWriteFile(plaintext, outputFile, 0644, -1, -1)
+	return utils.SaferWriteFile(plaintext, outputFile, utils.FileOptions{Perm: 0644})
 }
 
 // getCAStoreUpdater interates over known system trust store updaters and returns the first found.

--- a/google_guest_agent/agentcrypto/mtls_mds_linux.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_linux.go
@@ -55,7 +55,7 @@ func (j *CredsJob) writeRootCACert(ctx context.Context, content []byte, outputFi
 	if err := os.MkdirAll(filepath.Dir(outputFile), 0655); err != nil {
 		return err
 	}
-	if err := utils.SaferWriteFile(content, outputFile, 0644); err != nil {
+	if err := utils.SaferWriteFile(content, outputFile, 0644, -1, -1); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (j *CredsJob) writeClientCredentials(plaintext []byte, outputFile string) e
 	if err := os.MkdirAll(filepath.Dir(outputFile), 0655); err != nil {
 		return err
 	}
-	return utils.SaferWriteFile(plaintext, outputFile, 0644)
+	return utils.SaferWriteFile(plaintext, outputFile, 0644, -1, -1)
 }
 
 // getCAStoreUpdater interates over known system trust store updaters and returns the first found.

--- a/google_guest_agent/agentcrypto/mtls_mds_windows.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_windows.go
@@ -65,7 +65,7 @@ func (j *CredsJob) writeRootCACert(_ context.Context, cacert []byte, outputFile 
 		logger.Debugf("No previous MDS root certificate was found, will skip cleanup: %v", err)
 	}
 
-	if err := utils.SaferWriteFile(cacert, outputFile, 0644); err != nil {
+	if err := utils.SaferWriteFile(cacert, outputFile, 0644, -1, -1); err != nil {
 		return err
 	}
 
@@ -175,7 +175,7 @@ func (j *CredsJob) writeClientCredentials(creds []byte, outputFile string) error
 		logger.Warningf("Could not get previous serial number, will skip cleanup: %v", err)
 	}
 
-	if err := utils.SaferWriteFile(creds, outputFile, 0644); err != nil {
+	if err := utils.SaferWriteFile(creds, outputFile, 0644, -1, -1); err != nil {
 		return fmt.Errorf("failed to write client key: %w", err)
 	}
 
@@ -185,7 +185,7 @@ func (j *CredsJob) writeClientCredentials(creds []byte, outputFile string) error
 	}
 
 	p := filepath.Join(filepath.Dir(outputFile), pfxFile)
-	if err := utils.SaferWriteFile(pfx, p, 0644); err != nil {
+	if err := utils.SaferWriteFile(pfx, p, 0644, -1, -1); err != nil {
 		return fmt.Errorf("failed to write PFX file: %w", err)
 	}
 

--- a/google_guest_agent/agentcrypto/mtls_mds_windows.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_windows.go
@@ -65,7 +65,7 @@ func (j *CredsJob) writeRootCACert(_ context.Context, cacert []byte, outputFile 
 		logger.Debugf("No previous MDS root certificate was found, will skip cleanup: %v", err)
 	}
 
-	if err := utils.SaferWriteFile(cacert, outputFile, 0644, -1, -1); err != nil {
+	if err := utils.SaferWriteFile(cacert, outputFile, utils.FileOptions{Perm: 0644}); err != nil {
 		return err
 	}
 
@@ -175,7 +175,7 @@ func (j *CredsJob) writeClientCredentials(creds []byte, outputFile string) error
 		logger.Warningf("Could not get previous serial number, will skip cleanup: %v", err)
 	}
 
-	if err := utils.SaferWriteFile(creds, outputFile, 0644, -1, -1); err != nil {
+	if err := utils.SaferWriteFile(creds, outputFile, utils.FileOptions{Perm: 0644}); err != nil {
 		return fmt.Errorf("failed to write client key: %w", err)
 	}
 
@@ -185,7 +185,7 @@ func (j *CredsJob) writeClientCredentials(creds []byte, outputFile string) error
 	}
 
 	p := filepath.Join(filepath.Dir(outputFile), pfxFile)
-	if err := utils.SaferWriteFile(pfx, p, 0644, -1, -1); err != nil {
+	if err := utils.SaferWriteFile(pfx, p, utils.FileOptions{Perm: 0644}); err != nil {
 		return fmt.Errorf("failed to write PFX file: %w", err)
 	}
 

--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -107,6 +107,10 @@ command_pipe_group =
 command_request_timeout = 10s
 vlan_setup_enabled = false
 systemd_config_dir = /usr/lib/systemd/network
+set_fqdn = false
+set_hostname = false
+fqdn_as_hostname = false
+additional_aliases =
 `
 )
 
@@ -284,6 +288,10 @@ type Unstable struct {
 	CommandPipeGroup      string `ini:"command_pipe_group,omitempty"`
 	VlanSetupEnabled      bool   `ini:"vlan_setup_enabled,omitempty"`
 	SystemdConfigDir      string `ini:"systemd_config_dir,omitempty"`
+	SetFqdn               bool   `ini:"set_fqdn,omitempty"`
+	SetHostname           bool   `ini:"set_hostname,omitempty"`
+	AdditionalAliases     string `ini:"additional_aliases,omitempty"`
+	FqdnAsHostname        bool   `ini:"fqdn_as_hostname,omitempty"`
 }
 
 // WSFC contains the configurations of WSFC section.

--- a/google_guest_agent/command/command_monitor.go
+++ b/google_guest_agent/command/command_monitor.go
@@ -272,7 +272,13 @@ func getOption(b []byte) ([]byte, error) {
 			resp.StatusMessage = "Invalid option, key names must start with uppercase"
 			return json.Marshal(resp)
 		}
-		opt = reflect.Indirect(reflect.ValueOf(opt)).FieldByName(k).Interface()
+		field := reflect.Indirect(reflect.ValueOf(opt)).FieldByName(k)
+		if !field.IsValid() {
+			resp.Status = 1
+			resp.StatusMessage = "Option does not exist"
+			return json.Marshal(resp)
+		}
+		opt = field.Interface()
 	}
 	resp.Value = fmt.Sprintf("%v", opt)
 	return json.Marshal(resp)

--- a/google_guest_agent/command/command_test.go
+++ b/google_guest_agent/command/command_test.go
@@ -207,3 +207,39 @@ func TestListenTimeout(t *testing.T) {
 		t.Errorf("unexpected response from timed out connection, got %s but want %s", data, expect)
 	}
 }
+
+func TestGetOption(t *testing.T) {
+	cfg.Load(nil)
+	testcases := []struct {
+		name string
+		req  []byte
+		resp []byte
+	}{
+		{
+			name: "standard_case",
+			req:  []byte(`{"Command":"agent.config.getoption","Option":"InstanceSetup.NetworkEnabled"}`),
+			resp: []byte(`{"Status":0,"StatusMessage":"","Option":"InstanceSetup.NetworkEnabled","Value":"true"}`),
+		},
+		{
+			name: "unexported_field",
+			req:  []byte(`{"Command":"agent.config.getoption","Option":"InstanceSetup.networkEnabled"}`),
+			resp: []byte(`{"Status":3,"StatusMessage":"Invalid option, key names must start with uppercase","Option":"InstanceSetup.networkEnabled","Value":""}`),
+		},
+		{
+			name: "non_existent_field",
+			req:  []byte(`{"Command":"agent.config.getoption","Option":"BadOption"}`),
+			resp: []byte(`{"Status":0,"StatusMessage":"","Option":"InstanceSetup.NetworkEnabled","Value":"true"}`),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := getOption(tc.req)
+			if err != nil {
+				t.Errorf("error getting response from getOption(%s): %v", tc.req, err)
+			}
+			if string(b) != string(tc.resp) {
+				t.Errorf("unexpected response from getOption(%s), got %s want %s", tc.req, b, tc.resp)
+			}
+		})
+	}
+}

--- a/google_guest_agent/command/command_test.go
+++ b/google_guest_agent/command/command_test.go
@@ -228,7 +228,7 @@ func TestGetOption(t *testing.T) {
 		{
 			name: "non_existent_field",
 			req:  []byte(`{"Command":"agent.config.getoption","Option":"BadOption"}`),
-			resp: []byte(`{"Status":0,"StatusMessage":"","Option":"InstanceSetup.NetworkEnabled","Value":"true"}`),
+			resp: []byte(`{"Status":1,"StatusMessage":"Option does not exist","Option":"BadOption","Value":""}`),
 		},
 	}
 	for _, tc := range testcases {

--- a/google_guest_agent/hostname/hostname.go
+++ b/google_guest_agent/hostname/hostname.go
@@ -1,4 +1,4 @@
-//  Copyright 2019 Google Inc. All Rights Reserved.
+//  Copyright 2014 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/google_guest_agent/hostname/hostname.go
+++ b/google_guest_agent/hostname/hostname.go
@@ -1,0 +1,241 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package hostname reconfigures the guest hostname (linux only) and fqdn as necessary. It will do so on a detected change to the metadata hostname, when a new interface is configured, or a new ip address is acquired. It does so by triggering the HostnameReconfigure event, which is also triggerable outside the guest agent through named pipes on windows and unix sockets on linux. All of this behavior is configurable in the guest agent configuration.
+package hostname
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/command"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events/metadata"
+	mds "github.com/GoogleCloudPlatform/guest-agent/metadata"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+)
+
+var (
+	// ReconfigureHostnameCommand is the command id registered for hostname configuration
+	ReconfigureHostnameCommand = "agent.hostname.reconfigurehostname"
+	disallowedConfigurations   = map[string]bool{"": true, "metadata.google.internal": true}
+	hostnameFqdnMu             = new(sync.Mutex)
+	lastHostname               string //As retrieved from MDS
+	lastFqdn                   string //As retrieved from MDS
+)
+
+// ReconfigureHostnameRequest is the structure of requests to the ReconfigureHostnameCommand
+// Regardless of request options, guest agent will only set the hostname or fqdn if enabled in the MDS.
+type ReconfigureHostnameRequest struct {
+	command.Request
+}
+
+// ReconfigureHostnameResponse is the structure of responses from the ReconfigureHostnameCommand
+// Status code meanings:
+// 0: everything ok
+// 1: error setting hostname
+// 2: error setting fqdn
+// 3: error setting hostname and fqdn
+type ReconfigureHostnameResponse struct {
+	command.Response
+	// Hostname is the hostname which was set. Empty if unset, either due to configuration or error.
+	Hostname string
+	// Fqdn is the hostname which was set. Empty if unset, either due to configuration or error.
+	Fqdn string
+}
+
+// Init registers a hostname command handler and subscribes to the metadata longpoll event if the user has enabled network interface setup and either hostname or fqdn management.
+func Init(ctx context.Context, mdsclient mds.MDSClientInterface) {
+	if cfg.Get().Unstable.SetFqdn || cfg.Get().Unstable.SetHostname {
+		fqdn, err := mdsclient.GetKey(ctx, path.Join("instance", "hostname"), nil)
+		if err != nil {
+			logger.Errorf("could not get metadata hostname from MDS: %v", err)
+		} else if cfg.Get().Unstable.FqdnAsHostname {
+			lastHostname = fqdn
+			lastFqdn = fqdn
+		} else {
+			hostname, _, ok := strings.Cut(fqdn, ".")
+			if !ok {
+				logger.Errorf("metadata hostname %s is not an fqdn", fqdn)
+			} else {
+				lastFqdn = fqdn
+				lastHostname = hostname
+			}
+			b, err := ReconfigureHostname(nil)
+			if err != nil {
+				logger.Errorf("failed to call reconfigurehostname during setup: %v", err)
+			} else {
+				var resp ReconfigureHostnameResponse
+				err := json.Unmarshal(b, &resp)
+				if err != nil {
+					logger.Errorf("malformed response from reconfigurehostname: %v", err)
+				} else if resp.Status != 0 {
+					logger.Errorf("error reconfiguring hostname: %s", resp.StatusMessage)
+				}
+			}
+		}
+		events.Get().Subscribe(metadata.LongpollEvent, nil, processMdsEvent)
+		command.Get().RegisterHandler(ReconfigureHostnameCommand, ReconfigureHostname)
+		initPlatform(ctx)
+	}
+}
+
+// Close stops listening for events and unregisters command handlers
+func Close() {
+	events.Get().Unsubscribe(metadata.LongpollEvent, processMdsEvent)
+	command.Get().UnregisterHandler(ReconfigureHostnameCommand)
+}
+
+// ReconfigureHostname takes a ReconfigureHostnameRequest as a []byte-encoded
+// json blob and returns a ReconfigureHostnameResponse []byte-encoded json blob.
+func ReconfigureHostname(b []byte) ([]byte, error) {
+	hostnameFqdnMu.Lock()
+	defer hostnameFqdnMu.Unlock()
+
+	var req ReconfigureHostnameRequest
+	err := json.Unmarshal(b, &req)
+	if err != nil {
+		return nil, err
+	}
+	var hostname, fqdn string
+	fqdn = lastFqdn
+	if !cfg.Get().Unstable.FqdnAsHostname {
+		hostname = lastHostname
+	} else {
+		hostname = lastFqdn
+	}
+
+	var resp ReconfigureHostnameResponse
+	if cfg.Get().Unstable.SetHostname {
+		if disallowedConfigurations[hostname] {
+			resp.Status++
+			resp.StatusMessage += fmt.Sprintf("disallowed hostname: %q", hostname)
+		} else if err := setHostname(hostname); err != nil {
+			resp.Status++
+			resp.StatusMessage += err.Error()
+		} else {
+			resp.Hostname = hostname
+		}
+	}
+	if cfg.Get().Unstable.SetFqdn {
+		var err error
+		if runtime.GOOS != "windows" {
+			// Get the hostname from the OS in case we are configured to manage only the fqdn. Don't do this on windows because:
+			// 1) The hostname is always managed on Windows (albeit not by the agent: see https://github.com/GoogleCloudPlatform/compute-image-windows/blob/master/sysprep/activate_instance.ps1)
+			// 2) Windows truncates hostnames to 15 characters when they are set so we cannot rely on the OS to report the full hostname
+			hostname, err = os.Hostname()
+		}
+		if disallowedConfigurations[fqdn] {
+			err = fmt.Errorf("disallowed fqdn: %q", fqdn)
+		}
+		if err == nil {
+			err = setFqdn(hostname, fqdn)
+		}
+		if err != nil {
+			resp.Status += 2
+			resp.StatusMessage += err.Error()
+		} else {
+			resp.Fqdn = fqdn
+		}
+	}
+	return json.Marshal(resp)
+}
+
+func processMdsEvent(ctx context.Context, evType string, data interface{}, evData *events.EventData) bool {
+	descriptor, ok := data.(mds.Descriptor)
+	if !ok {
+		logger.Errorf("Bad descriptor from MDS longpoll event")
+	} else if shouldReconfigure(descriptor) {
+		_, err := ReconfigureHostname(nil)
+		if err != nil {
+			logger.Errorf("error reconfiguring hostname: %s", err)
+		}
+	}
+	return true // Always resubscribe to next descriptor change
+}
+
+func shouldReconfigure(descriptor mds.Descriptor) bool {
+	hostnameFqdnMu.Lock()
+	defer hostnameFqdnMu.Unlock()
+	var hostname, fqdn string
+	fqdn = descriptor.Instance.Hostname
+	if cfg.Get().Unstable.FqdnAsHostname {
+		hostname = fqdn
+	} else {
+		var ok bool
+		hostname, _, ok = strings.Cut(fqdn, ".")
+		if !ok {
+			logger.Errorf("metadata hostname %s is not an FQDN", fqdn)
+			return false
+		}
+	}
+	shouldReconfigure := false
+	if (hostname != lastHostname && cfg.Get().Unstable.SetHostname) || (fqdn != lastFqdn && cfg.Get().Unstable.SetFqdn) {
+		logger.Infof("hostname or fqdn changed in MDS and this change is managed by guest agent")
+		logger.Debugf("old hostname: %s new hostname: %s", lastHostname, hostname)
+		logger.Debugf("old fqdn: %s new fqdn: %s", lastFqdn, fqdn)
+		shouldReconfigure = true
+	}
+	lastHostname = hostname
+	lastFqdn = fqdn
+	return shouldReconfigure
+}
+
+var setFqdn = func(hostname, fqdn string) error {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return err
+	}
+	return writeHosts(hostname, fqdn, platformHostsFile, addrs)
+}
+
+func writeHosts(hostname, fqdn, hostsFile string, addrs []net.Addr) error {
+	var gcehosts []byte
+	var aliases string
+	hosts, err := os.ReadFile(hostsFile)
+	if err != nil {
+		return err
+	}
+	for _, l := range strings.Split(string(hosts), newline) {
+		if strings.HasSuffix(l, "# Added by Google") || l == "" {
+			continue
+		}
+		gcehosts = append(gcehosts, []byte(l)...)
+		gcehosts = append(gcehosts, []byte(newline)...)
+	}
+	for _, a := range strings.Split(cfg.Get().Unstable.AdditionalAliases, ",") {
+		aliases += a + " "
+	}
+	gcehosts = append(gcehosts, []byte(fmt.Sprintf("169.254.169.254 metadata.google.internal # Added by Google%s", newline))...)
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			logger.Errorf("Could not parse address %s: %v", addr, err)
+			continue
+		}
+		if !ip.IsLoopback() {
+			gcehosts = append(gcehosts, []byte(fmt.Sprintf("%s %s %s %s # Added by Google%s", ip, fqdn, hostname, aliases, newline))...)
+		}
+	}
+	// Platform specific, overwrite file with contents as atomicly as possible.
+	return overwrite(hostsFile, gcehosts)
+}

--- a/google_guest_agent/hostname/hostname.go
+++ b/google_guest_agent/hostname/hostname.go
@@ -1,4 +1,4 @@
-//  Copyright 2014 Google LLC
+//  Copyright 2024 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/google_guest_agent/hostname/hostname_linux.go
+++ b/google_guest_agent/hostname/hostname_linux.go
@@ -1,4 +1,4 @@
-//  Copyright 2019 Google Inc. All Rights Reserved.
+//  Copyright 2024 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+
+//go:build linux
 
 package hostname
 

--- a/google_guest_agent/hostname/hostname_linux.go
+++ b/google_guest_agent/hostname/hostname_linux.go
@@ -72,5 +72,7 @@ func overwrite(dst string, contents []byte) error {
 	if !ok {
 		return fmt.Errorf("could not determine owner of %s", dst)
 	}
-	return utils.SaferWriteFile(contents, dst, stat.Mode(), int(statT.Uid), int(statT.Gid))
+	uid := int(statT.Uid)
+	gid := int(statT.Gid)
+	return utils.SaferWriteFile(contents, dst, utils.FileOptions{Perm: stat.Mode(), UID: &uid, GID: &gid})
 }

--- a/google_guest_agent/hostname/hostname_linux.go
+++ b/google_guest_agent/hostname/hostname_linux.go
@@ -1,0 +1,92 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package hostname
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"syscall"
+)
+
+const (
+	platformHostsFile = "/etc/hosts"
+	newline           = "\n"
+)
+
+func initPlatform(context.Context) {}
+
+var setHostname = func(hostname string) error {
+	if err := syscall.Sethostname([]byte(hostname)); err != nil {
+		return err
+	}
+	if _, err := exec.LookPath("nmcli"); err == nil {
+		if err := exec.Command("nmcli", "general", "hostname", hostname).Run(); err != nil {
+			return err
+		}
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		o, err := exec.Command("systemctl").Output()
+		if err != nil {
+			return fmt.Errorf("error checking for rsyslog: %s", err)
+		}
+		if regexp.MustCompile(`rsyslog.service[^\n]*running`).Match(o) {
+			if err := exec.Command("systemctl", "--no-block", "restart", "rsyslog").Run(); err != nil {
+				return err
+			}
+		}
+	} else {
+		if err := exec.Command("pkill", "-HUP", "syslogd").Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Make the write as atomic as possible by creating a temp file, restoring
+// permissions & ownership, writing data, syncing, and then overwriting.
+func overwrite(dst string, contents []byte) error {
+	tmp, err := os.CreateTemp(os.TempDir(), "gcehosts")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+	stat, err := os.Stat(dst)
+	if err != nil {
+		return err
+	}
+	if statT, ok := stat.Sys().(*syscall.Stat_t); !ok {
+		return fmt.Errorf("could not determine owner of %s", dst)
+	} else if err := os.Chown(tmp.Name(), int(statT.Uid), int(statT.Gid)); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), stat.Mode()); err != nil {
+		return err
+	}
+	n, err := tmp.Write(contents)
+	if err != nil {
+		return err
+	}
+	if n != len(contents) {
+		return fmt.Errorf("Could not write entire hosts file, tried to write %d bytes but wrote %d", len(contents), n)
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), dst)
+}

--- a/google_guest_agent/hostname/hostname_test.go
+++ b/google_guest_agent/hostname/hostname_test.go
@@ -1,4 +1,4 @@
-//  Copyright 2019 Google Inc. All Rights Reserved.
+//  Copyright 2024 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/google_guest_agent/hostname/hostname_test.go
+++ b/google_guest_agent/hostname/hostname_test.go
@@ -1,0 +1,537 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package hostname
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/command"
+	mds "github.com/GoogleCloudPlatform/guest-agent/metadata"
+)
+
+func TestReconfigureHostname(t *testing.T) {
+	cfg.Load(nil)
+	setFqdnOrig := setFqdn
+	setHostnameOrig := setHostname
+	t.Cleanup(func() { setFqdn = setFqdnOrig; setHostname = setHostnameOrig })
+	testcases := []struct {
+		name         string
+		cfg          *cfg.Sections
+		lastHostname string
+		lastFqdn     string
+		setFqdn      func(string, string) error
+		setHostname  func(string) error
+		req          ReconfigureHostnameRequest
+		resp         ReconfigureHostnameResponse
+	}{
+		{
+			name: "successful reconfigure all",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Hostname: "host1",
+				Fqdn:     "host1.example.com",
+			},
+			lastHostname: "host1",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "fqdn as hostname",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: true,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Hostname: "host1.example.com",
+				Fqdn:     "host1.example.com",
+			},
+			lastHostname: "host1",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "reconfigure hostname",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        false,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Hostname: "host1",
+			},
+			lastHostname: "host1",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "reconfigure fqdn",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    false,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Fqdn: "host1.example.com",
+			},
+			lastHostname: "host1",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "fail to reconfigure hostname",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return fmt.Errorf("hostname failure") },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Response: command.Response{Status: 1, StatusMessage: "hostname failure"},
+				Fqdn:     "host1.example.com",
+			},
+			lastHostname: "host1",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "fail to reconfigure fqdn",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return fmt.Errorf("fqdn failure") },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Response: command.Response{Status: 2, StatusMessage: "fqdn failure"},
+				Hostname: "host1",
+			},
+			lastHostname: "host1",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "fail to reconfigure hostname and fqdn",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return fmt.Errorf("fqdn failure") },
+			setHostname: func(string) error { return fmt.Errorf("hostname failure") },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Response: command.Response{Status: 3, StatusMessage: "hostname failurefqdn failure"},
+			},
+			lastHostname: "host1",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "empty hostname",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Response: command.Response{Status: 1, StatusMessage: "disallowed hostname: \"\""},
+				Fqdn:     "host1.example.com",
+			},
+			lastHostname: "",
+			lastFqdn:     "host1.example.com",
+		},
+		{
+			name: "empty fqdn",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Response: command.Response{Status: 2, StatusMessage: "disallowed fqdn: \"\""},
+				Hostname: "host1",
+			},
+			lastHostname: "host1",
+			lastFqdn:     "",
+		},
+		{
+			name: "mds name as hostname",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			setFqdn:     func(string, string) error { return nil },
+			setHostname: func(string) error { return nil },
+			req:         ReconfigureHostnameRequest{},
+			resp: ReconfigureHostnameResponse{
+				Response: command.Response{Status: 3, StatusMessage: "disallowed hostname: \"metadata.google.internal\"disallowed fqdn: \"metadata.google.internal\""},
+			},
+			lastHostname: "metadata.google.internal",
+			lastFqdn:     "metadata.google.internal",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg.Get().Unstable = tc.cfg.Unstable
+			setFqdn = tc.setFqdn
+			setHostname = tc.setHostname
+			lastHostname = tc.lastHostname
+			lastFqdn = tc.lastFqdn
+			b, err := json.Marshal(tc.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b, err = ReconfigureHostname(b)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var resp ReconfigureHostnameResponse
+			err = json.Unmarshal(b, &resp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.Status != tc.resp.Status {
+				t.Errorf("unexpected status code from reconfigurehostname, got %d want %d", resp.Status, tc.resp.Status)
+			}
+			if resp.StatusMessage != tc.resp.StatusMessage {
+				t.Errorf("unexpected status message from reconfigurehostname, got %s want %s", resp.StatusMessage, tc.resp.StatusMessage)
+			}
+			if resp.Hostname != tc.resp.Hostname {
+				t.Errorf("unexpected hostname from reconfigurehostname, got %s want %s", resp.Hostname, tc.resp.Hostname)
+			}
+			if resp.Fqdn != tc.resp.Fqdn {
+				t.Errorf("unexpected fqdn from reconfigurehostname, got %s want %s", resp.Fqdn, tc.resp.Fqdn)
+			}
+		})
+	}
+}
+
+type fakeMdsClient struct{}
+
+func (f *fakeMdsClient) Get(context.Context) (*mds.Descriptor, error) { return nil, nil }
+func (f *fakeMdsClient) GetKey(context.Context, string, map[string]string) (string, error) {
+	return "host1.example.com", nil
+}
+func (f *fakeMdsClient) GetKeyRecursive(context.Context, string) (string, error)    { return "", nil }
+func (f *fakeMdsClient) Watch(context.Context) (*mds.Descriptor, error)             { return nil, nil }
+func (f *fakeMdsClient) WriteGuestAttributes(context.Context, string, string) error { return nil }
+
+func TestCommandRoundTrip(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cfg.Load(nil)
+	setFqdnOrig := setFqdn
+	setHostnameOrig := setHostname
+	t.Cleanup(func() { setFqdn = setFqdnOrig; setHostname = setHostnameOrig })
+	setFqdn = func(hostname, fqdn string) error {
+		if fqdn != "host1.example.com" {
+			return fmt.Errorf("bad fqdn")
+		}
+		return nil
+	}
+	setHostname = func(hostname string) error {
+		if hostname != "host1" {
+			return fmt.Errorf("bad hostname")
+		}
+		return nil
+	}
+	testpipe := path.Join(t.TempDir(), "commands.sock")
+	if runtime.GOOS == "windows" {
+		testpipe = `\\.\pipe\google-guest-agent-hostname-test-round-trip`
+	}
+	cfg.Get().Unstable = &cfg.Unstable{
+		CommandMonitorEnabled: true,
+		CommandPipePath:       testpipe,
+		FqdnAsHostname:        false,
+		SetHostname:           true,
+		SetFqdn:               true,
+	}
+	req := []byte(fmt.Sprintf(`{"Command":"%s"}`, ReconfigureHostnameCommand))
+	client := &fakeMdsClient{}
+	command.Init(ctx)
+	t.Cleanup(func() { command.Close() })
+	Init(ctx, client)
+	t.Cleanup(Close)
+	var resp ReconfigureHostnameResponse
+	b := command.SendCommand(ctx, req)
+	err := json.Unmarshal(b, &resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != 0 {
+		t.Errorf("unexpected status code from reconfigurehostname, got %d want %d", resp.Status, 0)
+	}
+	if resp.StatusMessage != "" {
+		t.Errorf("unexpected status message from reconfigurehostname, got %s want %s", resp.StatusMessage, "")
+	}
+	if resp.Hostname != "host1" {
+		t.Errorf("unexpected hostname from reconfigurehostname, got %s want %s", resp.Hostname, "host1")
+	}
+	if resp.Fqdn != "host1.example.com" {
+		t.Errorf("unexpected fqdn from reconfigurehostname, got %s want %s", resp.Fqdn, "host1.example.com")
+	}
+}
+
+func TestShouldReconfigure(t *testing.T) {
+	cfg.Load(nil)
+	testcases := []struct {
+		name               string
+		cfg                *cfg.Sections
+		lastHostname       string
+		lastFqdn           string
+		descriptor         mds.Descriptor
+		eventShouldTrigger bool
+	}{
+		{
+			name: "hostname changed",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        false,
+				},
+			},
+			lastHostname:       "host1",
+			lastFqdn:           "host1.example.com",
+			descriptor:         mds.Descriptor{Instance: mds.Instance{Hostname: "host2.example.com"}},
+			eventShouldTrigger: true,
+		},
+		{
+			name: "fqdn changed",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    false,
+					SetFqdn:        true,
+				},
+			},
+			lastHostname:       "host1",
+			lastFqdn:           "host1.example.net",
+			descriptor:         mds.Descriptor{Instance: mds.Instance{Hostname: "host1.example.com"}},
+			eventShouldTrigger: true,
+		},
+		{
+			name: "no change",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    true,
+					SetFqdn:        true,
+				},
+			},
+			lastHostname:       "host1",
+			lastFqdn:           "host1.example.com",
+			descriptor:         mds.Descriptor{Instance: mds.Instance{Hostname: "host1.example.com"}},
+			eventShouldTrigger: false,
+		},
+		{
+			name: "ignore changes",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: false,
+					SetHostname:    false,
+					SetFqdn:        false,
+				},
+			},
+			lastHostname:       "host1",
+			lastFqdn:           "host1.example.net",
+			descriptor:         mds.Descriptor{Instance: mds.Instance{Hostname: "host2.example.com"}},
+			eventShouldTrigger: false,
+		},
+		{
+			name: "fqnashostname changed",
+			cfg: &cfg.Sections{
+				Unstable: &cfg.Unstable{
+					FqdnAsHostname: true,
+					SetHostname:    true,
+					SetFqdn:        false,
+				},
+			},
+			lastHostname:       "host1",
+			lastFqdn:           "host1.example.net",
+			descriptor:         mds.Descriptor{Instance: mds.Instance{Hostname: "host1.example.net"}},
+			eventShouldTrigger: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg.Get().Unstable = tc.cfg.Unstable
+			lastHostname = tc.lastHostname
+			lastFqdn = tc.lastFqdn
+			o := shouldReconfigure(tc.descriptor)
+			if o != tc.eventShouldTrigger {
+				t.Errorf("shouldReconfigure reported unexpected value, got %v want %v", o, tc.eventShouldTrigger)
+			}
+		})
+	}
+}
+
+type testAddr struct{ s string }
+
+func (t testAddr) Network() string { return t.s }
+func (t testAddr) String() string  { return t.s }
+
+func TestWriteHosts(t *testing.T) {
+	cfg.Load(nil)
+	testcases := []struct {
+		name          string
+		cfg           *cfg.Sections
+		inputhosts    string
+		inputhostname string
+		inputfqdn     string
+		inputaddrs    []net.Addr
+		output        string
+	}{
+		{
+			name:          "empty hosts",
+			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
+			inputhosts:    "",
+			inputhostname: "tc1",
+			inputfqdn:     "tc1.example.com",
+			inputaddrs:    []net.Addr{testAddr{"10.0.0.10/16"}},
+			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
+		},
+		{
+			name:          "loopback addresses",
+			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
+			inputhosts:    "",
+			inputhostname: "tc1",
+			inputfqdn:     "tc1.example.com",
+			inputaddrs:    []net.Addr{testAddr{"10.0.0.10/16"}, testAddr{"127.0.0.1/8"}, testAddr{"::1/128"}},
+			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
+		},
+		{
+			name:          "two addresses",
+			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
+			inputhosts:    "",
+			inputhostname: "tc1",
+			inputfqdn:     "tc1.example.com",
+			inputaddrs:    []net.Addr{testAddr{"10.0.0.10/16"}, testAddr{"10.0.0.20/16"}},
+			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline + "10.0.0.20 tc1.example.com tc1   # Added by Google" + newline,
+		},
+		{
+			name:          "two aliases",
+			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{AdditionalAliases: "tc2,tc3"}},
+			inputhosts:    "",
+			inputhostname: "tc1",
+			inputfqdn:     "tc1.example.com",
+			inputaddrs:    []net.Addr{testAddr{"10.0.0.10/16"}},
+			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1 tc2 tc3  # Added by Google" + newline,
+		},
+		{
+			name:          "existing hosts at beginning",
+			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
+			inputhosts:    "127.0.0.1 pre-existing.host.com" + newline + "12.12.12.12 tc1.example.com # Added by Google" + newline,
+			inputhostname: "tc1",
+			inputfqdn:     "tc1.example.com",
+			inputaddrs:    []net.Addr{testAddr{"10.0.0.10/16"}},
+			output:        "127.0.0.1 pre-existing.host.com" + newline + "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
+		},
+		{
+			name:          "existing hosts at end",
+			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
+			inputhosts:    "12.12.12.12 tc1.example.com # Added by Google" + newline + "127.0.0.1 pre-existing.host.com" + newline + "",
+			inputhostname: "tc1",
+			inputfqdn:     "tc1.example.com",
+			inputaddrs:    []net.Addr{testAddr{"10.0.0.10/16"}},
+			output:        "127.0.0.1 pre-existing.host.com" + newline + "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
+		},
+		{
+			name:          "two gce hosts blocks",
+			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
+			inputhosts:    "12.12.12.12 tc1.example.com # Added by Google" + newline + "127.0.0.1 pre-existing.host.com" + newline + "13.13.13.13 tc2.example.com # Added by Google" + newline,
+			inputhostname: "tc1",
+			inputfqdn:     "tc1.example.com",
+			inputaddrs:    []net.Addr{testAddr{"10.0.0.10/16"}},
+			output:        "127.0.0.1 pre-existing.host.com" + newline + "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg.Get().Unstable = tc.cfg.Unstable
+			testfile, err := os.CreateTemp(t.TempDir(), "test-writehosts-"+strings.ReplaceAll(tc.name, " ", "-"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err = testfile.Write([]byte(tc.inputhosts)); err != nil {
+				t.Fatal(err)
+			}
+			hostsfile := testfile.Name()
+			if err = testfile.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := writeHosts(tc.inputhostname, tc.inputfqdn, hostsfile, tc.inputaddrs); err != nil {
+				t.Fatal(err)
+			}
+			output, err := os.ReadFile(hostsfile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(output) != tc.output {
+				t.Errorf("unexpected output from writeHosts, want "+newline+"%q"+newline+"but got"+newline+"%q", tc.output, output)
+			}
+		})
+	}
+}

--- a/google_guest_agent/hostname/hostname_test.go
+++ b/google_guest_agent/hostname/hostname_test.go
@@ -46,7 +46,7 @@ func TestReconfigureHostname(t *testing.T) {
 		resp         ReconfigureHostnameResponse
 	}{
 		{
-			name: "successful reconfigure all",
+			name: "successful_reconfigure_all",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -65,7 +65,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "fqdn as hostname",
+			name: "fqdn_as_hostname",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: true,
@@ -84,7 +84,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "reconfigure hostname",
+			name: "reconfigure_hostname",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -102,7 +102,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "reconfigure fqdn",
+			name: "reconfigure_fqdn",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -120,7 +120,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "fail to reconfigure hostname",
+			name: "fail_to_reconfigure_hostname",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -139,7 +139,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "fail to reconfigure fqdn",
+			name: "fail_to_reconfigure_fqdn",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -158,7 +158,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "fail to reconfigure hostname and fqdn",
+			name: "fail_to_reconfigure_hostname_and_fqdn",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -176,7 +176,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "empty hostname",
+			name: "empty_hostname",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -195,7 +195,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "host1.example.com",
 		},
 		{
-			name: "empty fqdn",
+			name: "empty_fqdn",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -214,7 +214,7 @@ func TestReconfigureHostname(t *testing.T) {
 			lastFqdn:     "",
 		},
 		{
-			name: "mds name as hostname",
+			name: "mds_name_as_hostname",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -345,7 +345,7 @@ func TestShouldReconfigure(t *testing.T) {
 		eventShouldTrigger bool
 	}{
 		{
-			name: "hostname changed",
+			name: "hostname_changed",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -359,7 +359,7 @@ func TestShouldReconfigure(t *testing.T) {
 			eventShouldTrigger: true,
 		},
 		{
-			name: "fqdn changed",
+			name: "fqdn_changed",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -373,7 +373,7 @@ func TestShouldReconfigure(t *testing.T) {
 			eventShouldTrigger: true,
 		},
 		{
-			name: "no change",
+			name: "no_change",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -387,7 +387,7 @@ func TestShouldReconfigure(t *testing.T) {
 			eventShouldTrigger: false,
 		},
 		{
-			name: "ignore changes",
+			name: "ignore_changes",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: false,
@@ -401,7 +401,7 @@ func TestShouldReconfigure(t *testing.T) {
 			eventShouldTrigger: false,
 		},
 		{
-			name: "fqnashostname changed",
+			name: "fqnashostname_changed",
 			cfg: &cfg.Sections{
 				Unstable: &cfg.Unstable{
 					FqdnAsHostname: true,
@@ -445,7 +445,7 @@ func TestWriteHosts(t *testing.T) {
 		output        string
 	}{
 		{
-			name:          "empty hosts",
+			name:          "empty_hosts",
 			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
 			inputhosts:    "",
 			inputhostname: "tc1",
@@ -454,7 +454,7 @@ func TestWriteHosts(t *testing.T) {
 			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
 		},
 		{
-			name:          "loopback addresses",
+			name:          "loopback_addresses",
 			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
 			inputhosts:    "",
 			inputhostname: "tc1",
@@ -463,7 +463,7 @@ func TestWriteHosts(t *testing.T) {
 			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
 		},
 		{
-			name:          "two addresses",
+			name:          "two_addresses",
 			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
 			inputhosts:    "",
 			inputhostname: "tc1",
@@ -472,7 +472,7 @@ func TestWriteHosts(t *testing.T) {
 			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline + "10.0.0.20 tc1.example.com tc1   # Added by Google" + newline,
 		},
 		{
-			name:          "two aliases",
+			name:          "two_aliases",
 			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{AdditionalAliases: "tc2,tc3"}},
 			inputhosts:    "",
 			inputhostname: "tc1",
@@ -481,7 +481,7 @@ func TestWriteHosts(t *testing.T) {
 			output:        "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1 tc2 tc3  # Added by Google" + newline,
 		},
 		{
-			name:          "existing hosts at beginning",
+			name:          "existing_hosts_at_beginning",
 			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
 			inputhosts:    "127.0.0.1 pre-existing.host.com" + newline + "12.12.12.12 tc1.example.com # Added by Google" + newline,
 			inputhostname: "tc1",
@@ -490,7 +490,7 @@ func TestWriteHosts(t *testing.T) {
 			output:        "127.0.0.1 pre-existing.host.com" + newline + "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
 		},
 		{
-			name:          "existing hosts at end",
+			name:          "existing_hosts_at_end",
 			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
 			inputhosts:    "12.12.12.12 tc1.example.com # Added by Google" + newline + "127.0.0.1 pre-existing.host.com" + newline + "",
 			inputhostname: "tc1",
@@ -499,7 +499,7 @@ func TestWriteHosts(t *testing.T) {
 			output:        "127.0.0.1 pre-existing.host.com" + newline + "169.254.169.254 metadata.google.internal # Added by Google" + newline + "10.0.0.10 tc1.example.com tc1   # Added by Google" + newline,
 		},
 		{
-			name:          "two gce hosts blocks",
+			name:          "two_gce_hosts_blocks",
 			cfg:           &cfg.Sections{Unstable: &cfg.Unstable{}},
 			inputhosts:    "12.12.12.12 tc1.example.com # Added by Google" + newline + "127.0.0.1 pre-existing.host.com" + newline + "13.13.13.13 tc2.example.com # Added by Google" + newline,
 			inputhostname: "tc1",

--- a/google_guest_agent/hostname/hostname_windows.go
+++ b/google_guest_agent/hostname/hostname_windows.go
@@ -1,0 +1,121 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package hostname
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/command"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	platformHostsFile = `C:\Windows\System32\Drivers\etc\hosts`
+	newline           = "\r\n"
+)
+
+var (
+	ipcallbackHandleMu          = new(sync.Mutex)
+	ipcallbackHandle            uintptr
+	iphlpapi                    = windows.NewLazySystemDLL("iphlpapi.dll")
+	procNotifyIpInterfaceChange = iphlpapi.NewProc("NotifyIpInterfaceChange")
+	procCancelMibChangeNotify2  = iphlpapi.NewProc("CancelMibChangeNotify2")
+)
+
+var setHostname = func(hostname string) error {
+	return fmt.Errorf("setting hostnames in guest-agent is not supported on windows")
+}
+
+func notifyIpInterfaceChange(family uint32, callbackPtr uintptr, callerContext unsafe.Pointer, initialNotif bool, handle *uintptr) error {
+	notify := 0
+	if initialNotif {
+		notify = 1
+	}
+
+	r, _, e := procNotifyIpInterfaceChange.Call(
+		uintptr(family),                 // Address family
+		callbackPtr,                     // callback ptr
+		uintptr(callerContext),          // caller context
+		uintptr(notify),                 // call callback immediately after registration
+		uintptr(unsafe.Pointer(handle)), // handle for deregistering callback
+	)
+	if r != 0 {
+		return e
+	}
+	return nil
+}
+
+func cancelMibChangeNotify2(handle uintptr) (err error) {
+	r, _, e := procCancelMibChangeNotify2.Call(handle)
+	if r != 0 {
+		return e
+	}
+	return nil
+}
+
+func initPlatform(ctx context.Context) {
+	ipcallbackHandleMu.Lock()
+	defer ipcallbackHandleMu.Unlock()
+	if ipcallbackHandle != 0 {
+		logger.Infof("ip callback is already registered")
+		return
+	}
+	callback := func() uintptr {
+		logger.Infof("ip interface changed, reconfiguring fqdn")
+		req := []byte(fmt.Sprintf(`{"Command":"%s"}`, ReconfigureHostnameCommand))
+		b := command.SendCommand(ctx, req)
+		logger.Debugf("got response: %s from reconfigure request", b)
+		return 0 // Report success
+	}
+	err := notifyIpInterfaceChange(
+		syscall.AF_UNSPEC, //ipv4+6
+		syscall.NewCallback(callback),
+		nil, // Don't need to pass any caller context
+		false,
+		&ipcallbackHandle,
+	)
+	if err != nil {
+		logger.Errorf("unable to register callback for ip interface change: %v", err)
+	}
+}
+
+func closePlatform() {
+	ipcallbackHandleMu.Lock()
+	defer ipcallbackHandleMu.Unlock()
+	if ipcallbackHandle == 0 {
+		logger.Infof("ip callback handle is not registered")
+		return
+	}
+	err := cancelMibChangeNotify2(ipcallbackHandle)
+	if err != nil {
+		logger.Errorf("unable to unregister callback for ip interface change: %v", err)
+	}
+}
+
+// Windows does not promise atomic moves so there is no point doing anything
+// but writing directly to the file.
+func overwrite(dst string, contents []byte) error {
+	stat, err := os.Stat(dst)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, contents, stat.Mode())
+}

--- a/google_guest_agent/hostname/hostname_windows.go
+++ b/google_guest_agent/hostname/hostname_windows.go
@@ -23,6 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/command"
+	"github.com/GoogleCloudPlatform/guest-agent/utils"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"golang.org/x/sys/windows"
 )
@@ -110,12 +111,10 @@ func closePlatform() {
 	}
 }
 
-// Windows does not promise atomic moves so there is no point doing anything
-// but writing directly to the file.
 func overwrite(dst string, contents []byte) error {
 	stat, err := os.Stat(dst)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dst, contents, stat.Mode())
+	return utils.SaferWriteFile(dst, contents, stat.Mode(), -1, -1)
 }

--- a/google_guest_agent/hostname/hostname_windows.go
+++ b/google_guest_agent/hostname/hostname_windows.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"syscall"
 	"unsafe"
 
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/command"
@@ -89,8 +88,8 @@ func initPlatform(ctx context.Context) {
 		return 0 // Report success
 	}
 	err := notifyIpInterfaceChange(
-		syscall.AF_UNSPEC, //ipv4+6
-		syscall.NewCallback(callback),
+		windows.AF_UNSPEC, //ipv4+6
+		windows.NewCallback(callback),
 		nil, // Don't need to pass any caller context
 		false,
 		&ipcallbackHandle,

--- a/google_guest_agent/hostname/hostname_windows.go
+++ b/google_guest_agent/hostname/hostname_windows.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"syscall"
 	"unsafe"
 
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/command"
@@ -52,7 +53,7 @@ func notifyIpInterfaceChange(family uint32, callbackPtr uintptr, callerContext u
 		notify = 1
 	}
 
-	r, _, e := procNotifyIpInterfaceChange.Call(
+	r, _, e := syscall.SyscallN(procNotifyIpInterfaceChange.Addr(),
 		uintptr(family),                 // Address family
 		callbackPtr,                     // callback ptr
 		uintptr(callerContext),          // caller context
@@ -66,7 +67,7 @@ func notifyIpInterfaceChange(family uint32, callbackPtr uintptr, callerContext u
 }
 
 func cancelMibChangeNotify2(handle uintptr) (err error) {
-	r, _, e := procCancelMibChangeNotify2.Call(handle)
+	r, _, e := syscall.SyscallN(procCancelMibChangeNotify2.Addr(), handle)
 	if r != 0 {
 		return e
 	}

--- a/google_guest_agent/hostname/hostname_windows.go
+++ b/google_guest_agent/hostname/hostname_windows.go
@@ -116,5 +116,5 @@ func overwrite(dst string, contents []byte) error {
 	if err != nil {
 		return err
 	}
-	return utils.SaferWriteFile(dst, contents, stat.Mode(), -1, -1)
+	return utils.SaferWriteFile(contents, dst, stat.Mode(), -1, -1)
 }

--- a/google_guest_agent/hostname/hostname_windows.go
+++ b/google_guest_agent/hostname/hostname_windows.go
@@ -117,5 +117,5 @@ func overwrite(dst string, contents []byte) error {
 	if err != nil {
 		return err
 	}
-	return utils.SaferWriteFile(contents, dst, stat.Mode(), -1, -1)
+	return utils.SaferWriteFile(contents, dst, utils.FileOptions{Perm: stat.Mode()})
 }

--- a/google_guest_agent/hostname/hostname_windows.go
+++ b/google_guest_agent/hostname/hostname_windows.go
@@ -1,4 +1,4 @@
-//  Copyright 2019 Google Inc. All Rights Reserved.
+//  Copyright 2024 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+
+//go:build windows
 
 package hostname
 

--- a/google_guest_agent/hostname/hostname_windows_test.go
+++ b/google_guest_agent/hostname/hostname_windows_test.go
@@ -1,4 +1,4 @@
-//  Copyright 2024 Google LLC.
+//  Copyright 2024 Google LLC
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+
 //go:build windows
 
 package hostname

--- a/google_guest_agent/hostname/hostname_windows_test.go
+++ b/google_guest_agent/hostname/hostname_windows_test.go
@@ -17,8 +17,9 @@
 package hostname
 
 import (
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestNotifyIpInterfaceChange(t *testing.T) {
@@ -28,7 +29,7 @@ func TestNotifyIpInterfaceChange(t *testing.T) {
 		callbackExecuted = true
 		return 0
 	}
-	if err := notifyIpInterfaceChange(syscall.AF_UNSPEC, syscall.NewCallback(callback), nil, true, &handle); err != nil {
+	if err := notifyIpInterfaceChange(windows.AF_UNSPEC, windows.NewCallback(callback), nil, true, &handle); err != nil {
 		t.Errorf("failed to register callback: %v", err)
 	}
 	if handle == 0 {

--- a/google_guest_agent/hostname/hostname_windows_test.go
+++ b/google_guest_agent/hostname/hostname_windows_test.go
@@ -1,3 +1,16 @@
+//  Copyright 2024 Google LLC.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //go:build windows
 
 package hostname
@@ -5,7 +18,6 @@ package hostname
 import (
 	"syscall"
 	"testing"
-	"time"
 )
 
 func TestNotifyIpInterfaceChange(t *testing.T) {
@@ -21,7 +33,6 @@ func TestNotifyIpInterfaceChange(t *testing.T) {
 	if handle == 0 {
 		t.Error("notification handle is nil after registering callback")
 	}
-	time.Sleep(1 * time.Second)
 	if !callbackExecuted {
 		t.Errorf("callback was not executed, callbackExecuted = %v", callbackExecuted)
 	}

--- a/google_guest_agent/hostname/hostname_windows_test.go
+++ b/google_guest_agent/hostname/hostname_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package hostname
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestNotifyIpInterfaceChange(t *testing.T) {
+	var handle uintptr
+	var callbackExecuted bool
+	callback := func() uintptr {
+		callbackExecuted = true
+		return 0
+	}
+	if err := notifyIpInterfaceChange(syscall.AF_UNSPEC, syscall.NewCallback(callback), nil, true, &handle); err != nil {
+		t.Errorf("failed to register callback: %v", err)
+	}
+	if handle == 0 {
+		t.Error("notification handle is nil after registering callback")
+	}
+	time.Sleep(1 * time.Second)
+	if !callbackExecuted {
+		t.Errorf("callback was not executed, callbackExecuted = %v", callbackExecuted)
+	}
+	if err := cancelMibChangeNotify2(handle); err != nil {
+		t.Errorf("failed to unregister callback: %v", err)
+	}
+}

--- a/google_guest_agent/network/manager/wicked_linux.go
+++ b/google_guest_agent/network/manager/wicked_linux.go
@@ -249,6 +249,9 @@ func (n wicked) writeEthernetConfigs(ifaces []string) error {
 			"BOOTPROTO=dhcp",
 			fmt.Sprintf("DHCLIENT_ROUTE_PRIORITY=%d", priority),
 		}
+		if cfg.Get().Unstable.SetHostname || cfg.Get().Unstable.SetFqdn {
+			contents = append(contents, `POST_UP_SCRIPT="compat:suse:google_up.sh"`)
+		}
 		_, err = ifcfg.WriteString(strings.Join(contents, "\n"))
 		if err != nil {
 			return fmt.Errorf("error writing config file for %s: %v", iface, err)

--- a/google_guest_agent/network/manager/wicked_linux_test.go
+++ b/google_guest_agent/network/manager/wicked_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
 )
 
@@ -238,6 +239,7 @@ func TestIsManaging(t *testing.T) {
 // TestWriteEthernetConfigs tests whether the wicked configuration files are
 // written correctly and to the right location.
 func TestWriteEthernetConfigs(t *testing.T) {
+	cfg.Load(nil)
 	tests := []struct {
 		// name is the name of the test.
 		name string

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -138,6 +138,9 @@ type Instance struct {
 	// ID is the instance ID.
 	ID json.Number
 
+	// Hostname is the instance fqdn
+	Hostname string
+
 	// MachineType represents the instance's machine type.
 	MachineType string
 

--- a/utils/file_linux_test.go
+++ b/utils/file_linux_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package utils
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestSaferWriteFileWithUserAndGroup(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("could not get current user: %v", err)
+	}
+	uid, err := strconv.Atoi(currentUser.Uid)
+	if err != nil {
+		t.Fatalf("current uid is not an int: %v", err)
+	}
+	gid, err := strconv.Atoi(currentUser.Gid)
+	if err != nil {
+		t.Fatalf("current gid is not an int: %v", err)
+	}
+	currentGroups, err := currentUser.GroupIds()
+	if err != nil {
+		t.Fatalf("could not get user groups for %s: %v", currentUser.Name, err)
+	}
+	// Try to use a supplemental group that doesn't match the user's default group
+	// for testing purposes.
+	for _, grp := range currentGroups {
+		if grp != currentUser.Gid {
+			var err error
+			gid, err = strconv.Atoi(currentUser.Gid)
+			if err == nil {
+				break
+			}
+		}
+	}
+	f := filepath.Join(t.TempDir(), "file")
+	want := "test-data"
+
+	if err := SaferWriteFile([]byte(want), f, FileOptions{Perm: 0644, UID: &uid, GID: &gid}); err != nil {
+		t.Errorf("SaferWriteFile(%s, %s) failed unexpectedly with err: %+v", "test-data", f, err)
+	}
+
+	got, err := os.ReadFile(f)
+	if err != nil {
+		t.Errorf("os.ReadFile(%s) failed unexpectedly with err: %+v", f, err)
+	}
+	if string(got) != want {
+		t.Errorf("os.ReadFile(%s) = %s, want %s", f, string(got), want)
+	}
+
+	i, err := os.Stat(f)
+	if err != nil {
+		t.Errorf("os.Stat(%s) failed unexpectedly with err: %+v", f, err)
+	}
+	statT, ok := i.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Errorf("could not determine owner of %s", f)
+	}
+	if int(statT.Uid) != uid {
+		t.Errorf("unexepected uid, got %d want %d", statT.Uid, uid)
+	}
+	if int(statT.Gid) != gid {
+		t.Errorf("unexepected gid, got %d want %d", statT.Gid, gid)
+	}
+
+	if i.Mode().Perm() != 0o644 {
+		t.Errorf("SaferWriteFile(%s) set incorrect permissions, os.Stat(%s) = %o, want %o", f, f, i.Mode().Perm(), 0o644)
+	}
+}

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -24,7 +24,7 @@ func TestSaferWriteFile(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "file")
 	want := "test-data"
 
-	if err := SaferWriteFile([]byte(want), f, 0644, -1, -1); err != nil {
+	if err := SaferWriteFile([]byte(want), f, FileOptions{Perm: 0644}); err != nil {
 		t.Errorf("SaferWriteFile(%s, %s) failed unexpectedly with err: %+v", "test-data", f, err)
 	}
 

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -24,7 +24,7 @@ func TestSaferWriteFile(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "file")
 	want := "test-data"
 
-	if err := SaferWriteFile([]byte(want), f, 0644); err != nil {
+	if err := SaferWriteFile([]byte(want), f, 0644, -1, -1); err != nil {
 		t.Errorf("SaferWriteFile(%s, %s) failed unexpectedly with err: %+v", "test-data", f, err)
 	}
 


### PR DESCRIPTION
* Add `hostname` field to the metadata descriptor
* Add `set_hostname` `fqdn_as_hostname` `set_fqdn` and `additional_aliases` configuration options
* Add a `get_config_option` action to `google_guest_agent` which loads the config and prints a string representation of the given option (ex: `NetworkInterfaces.Setup` prints true by default)
* Change config file load order so that distro defaults do not take priority over user options.
* Add a dependency on Microsoft's [winio](https://github.com/Microsoft/go-winio) library for named pipes.
* Add a network event watcher which triggers network events based on:
  - Writes to a socket from other programs on the OS. This  uses named pipes on windows, unix sockets on linux. (Associated guest-configs change to write to these sockets is [here](https://github.com/GoogleCloudPlatform/guest-configs/pull/60))
  - Kernel IP APIs signalling a change in network configuration (windows only)
* Add a hostname package which subscribes to the following events:
  - `metadata-watcher,longpoll`: checks whether the last hostname and fqdn differ from the one returned by the MDS whenever the MDS descriptor changes, triggering a hostname reconfigure if necessary
  - `network-watcher,iface-up`: triggers a hostname reconfigure event whenever an interface comes up on the system
  - `network-watcher,hostname-reconfigure`: retrieves the hostname and fqdn from the MDS, setting each depending on the guest-agent configuration

These changes will not cause any issue if guest-agent is updated without updating guest-configs on linux, it simply will not receive events and not trigger any hostname/fqdn configuration beyond the initial trigger.