### PR TITLE
Add prefix to scheduler logs

### DIFF
--- a/google_guest_agent/scheduler/logger.go
+++ b/google_guest_agent/scheduler/logger.go
@@ -21,9 +21,9 @@ import (
 type cronLogger struct{}
 
 func (cl *cronLogger) Info(msg string, keysAndValues ...any) {
-	logger.Infof("%s: %+v", msg, keysAndValues)
+	logger.Infof("Scheduler - %s: %+v", msg, keysAndValues)
 }
 
 func (cl *cronLogger) Error(err error, msg string, keysAndValues ...any) {
-	logger.Infof("%s: %+v", msg, keysAndValues)
+	logger.Infof("Scheduler - %s: %+v", msg, keysAndValues)
 }

--- a/google_guest_agent/scheduler/scheduler.go
+++ b/google_guest_agent/scheduler/scheduler.go
@@ -69,6 +69,7 @@ func Get() *Scheduler {
 // getFunc generates a wrapper function for cron scheduler.
 func (s *Scheduler) getFunc(ctx context.Context, job Job) func() {
 	f := func() {
+		logger.Infof("Invoking job %q", job.ID())
 		schedule, err := job.Run(ctx)
 		if !schedule {
 			s.UnscheduleJob(job.ID())


### PR DESCRIPTION
* Adds prefix to the scheduler logs to provide context on where the logs are coming from
* Log when job is invoked