### PR TITLE
revert: 3ddd9d4a496f7a9c591ded58c3f541fd9cc7e317

### DIFF
--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -296,9 +296,9 @@ func defaultDataSources(extraDefaults []byte) []interface{} {
 	}
 
 	return append(res, []interface{}{
+		config,
 		config + ".distro",
 		config + ".template",
-		config,
 	}...)
 }
 


### PR DESCRIPTION
This PR reverts the config loading ordering change to comply with the documentation, we found out that we have users relying on the wrong/non documented behavior.