### PR TITLE
Deprecate DHClient in favor of systemd-networkd

### DIFF
--- a/google_guest_agent/network/manager/common.go
+++ b/google_guest_agent/network/manager/common.go
@@ -1,0 +1,86 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package manager is responsible for detecting the current network manager service, and
+// writing and rolling back appropriate configurations for each network manager service.
+package manager
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+)
+
+var (
+	badMAC = make(map[string]net.Interface)
+)
+
+// interfaceNames extracts the names of the network interfaces from the provided list
+// of network interfaces.
+func interfaceNames(nics []metadata.NetworkInterfaces) ([]string, error) {
+	var ifaces []string
+	for _, ni := range nics {
+		iface, err := GetInterfaceByMAC(ni.Mac)
+		if err != nil {
+			return nil, err
+		}
+		ifaces = append(ifaces, iface.Name)
+	}
+	return ifaces, nil
+}
+
+// interfaceListsIpv4Ipv6 gets a list of interface names. The first list is a list of all
+// interfaces, and the second list consists of only interfaces that support IPv6.
+func interfaceListsIpv4Ipv6(nics []metadata.NetworkInterfaces) ([]string, []string) {
+	var googleInterfaces []string
+	var googleIpv6Interfaces []string
+
+	for _, ni := range nics {
+		iface, err := GetInterfaceByMAC(ni.Mac)
+		if err != nil {
+			if _, found := badMAC[ni.Mac]; !found {
+				logger.Errorf("error getting interface: %s", err)
+				badMAC[ni.Mac] = iface
+			}
+			continue
+		}
+		if ni.DHCPv6Refresh != "" {
+			googleIpv6Interfaces = append(googleIpv6Interfaces, iface.Name)
+		}
+		googleInterfaces = append(googleInterfaces, iface.Name)
+	}
+	return googleInterfaces, googleIpv6Interfaces
+}
+
+// GetInterfaceByMAC gets the interface given the mac string.
+func GetInterfaceByMAC(mac string) (net.Interface, error) {
+	hwaddr, err := net.ParseMAC(mac)
+	if err != nil {
+		return net.Interface{}, err
+	}
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return net.Interface{}, fmt.Errorf("failed to get interfaces: %v", err)
+	}
+
+	for _, iface := range interfaces {
+		if iface.HardwareAddr.String() == hwaddr.String() {
+			return iface, nil
+		}
+	}
+	return net.Interface{}, fmt.Errorf("no interface found with MAC %s", mac)
+}

--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -1,0 +1,285 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package manager is responsible for detecting the current network manager service, and
+// writing and rolling back appropriate configurations for each network manager service.
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/ps"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+)
+
+const (
+	// The base directory for dhclient files managed by guest agent.
+	baseDhclientDir = "/var/google-dhclient.d"
+
+	// For finer control of the execution, dhclient is invoked for
+	// each interface individually such that each call will have its
+	// own PID file. This is where those PID files are expected to be
+	// written.
+	pidFileDir = "pids"
+
+	// Similar thing for PID files, but for DHClient leases.
+	leaseFileDir = "leases"
+)
+
+var (
+	// ipv4 is a wrapper containing the protocol version and its respective
+	// dhclient argument.
+	ipv4 = ipVersion{"ipv4", "-4"}
+
+	// ipv6 is a wrapper containing the protocol version and its respective
+	// dhclient argument.
+	ipv6 = ipVersion{"ipv6", "-6"}
+)
+
+// ipVersion is a wrapper containing the human-readable version string and
+// the respective dhclient argument.
+type ipVersion struct {
+	// version is the human-readable IP protocol version.
+	version string
+
+	// dhclientArg is the respective argument for DHClient invocation.
+	dhclientArg string
+}
+
+// dhclient implements the manager.Service interface for dhclient use cases.
+type dhclient struct{}
+
+// init adds this network manager service to the list of known network managers.
+// DHClient will be the default fallback.
+func init() {
+	registerManager(&dhclient{}, true)
+}
+
+// Name returns the name of the network manager service.
+func (n dhclient) Name() string {
+	return "dhclient"
+}
+
+// IsManaging checks if the dhclient CLI is available.
+func (n dhclient) IsManaging(ctx context.Context, iface string) (bool, error) {
+	// Check if the dhclient CLI exists.
+	if _, err := exec.LookPath("dhclient"); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error looking up dhclient path: %v", err)
+	}
+	return true, nil
+}
+
+// Setup sets up the non-primary interfaces with dhclient, having different setup procedures
+// for IPv6 network interfaces and IPv4 network interfaces.
+func (n dhclient) Setup(ctx context.Context, config *cfg.Sections, payload []metadata.NetworkInterfaces) error {
+	dhcpCommand := config.NetworkInterfaces.DHCPCommand
+	if dhcpCommand != "" {
+		tokens := strings.Split(dhcpCommand, " ")
+		return run.Quiet(ctx, tokens[0], tokens[1:]...)
+	}
+
+	// Create the necessary directories.
+	if err := os.MkdirAll(fmt.Sprintf("%s/%s", baseDhclientDir, pidFileDir), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+	if err := os.MkdirAll(fmt.Sprintf("%s/%s", baseDhclientDir, leaseFileDir), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	// Get all interfaces separated by ipv4 and ipv6.
+	googleInterfaces, googleIpv6Interfaces := interfaceListsIpv4Ipv6(payload)
+	obtainIpv4Interfaces, obtainIpv6Interfaces, releaseIpv6Interfaces, err := partitionInterfaces(ctx, googleInterfaces, googleIpv6Interfaces)
+	if err != nil {
+		return fmt.Errorf("error partitioning interfaces: %v", err)
+	}
+
+	// Release IPv6 leases.
+	for _, iface := range releaseIpv6Interfaces {
+		if err := runDhclient(ctx, ipv6, iface, true); err != nil {
+			logger.Errorf("failed to run dhclient: %+x", err)
+		}
+	}
+
+	// Setup IPV4.
+	for _, iface := range obtainIpv4Interfaces {
+		if err := runDhclient(ctx, ipv4, iface, false); err != nil {
+			logger.Errorf("failed to run dhclient: %+x", err)
+		}
+	}
+
+	if len(obtainIpv6Interfaces) == 0 {
+		return nil
+	}
+
+	// Wait for tentative IPs to resolve as part of SLAAC for primary network interface.
+	tentative := []string{"-6", "-o", "a", "s", "dev", googleInterfaces[0], "scope", "link", "tentative"}
+	for i := 0; i < 5; i++ {
+		res := run.WithOutput(ctx, "ip", tentative...)
+		if res.ExitCode == 0 && res.StdOut == "" {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	// Setup IPv6.
+	for _, iface := range obtainIpv6Interfaces {
+		// Set appropriate system values.
+		val := fmt.Sprintf("net.ipv6.conf.%s.accept_ra_rt_info_max_plen=128", iface)
+		if err := run.Quiet(ctx, "sysctl", val); err != nil {
+			return err
+		}
+
+		if err := runDhclient(ctx, ipv6, iface, false); err != nil {
+			logger.Errorf("failed to run dhclient: %+x", err)
+		}
+	}
+	return nil
+}
+
+// pidFilePath gets the expected file path for the PID pertaining to the provided
+// interface and IP version.
+func pidFilePath(iface string, ipVersion ipVersion) string {
+	return path.Join(baseDhclientDir, pidFileDir, fmt.Sprintf("dhclient.google-guest-agent.%s.%s.pid", iface, ipVersion.version))
+}
+
+// leaseFilePath gets the expected file path for the leases pertaining to the provided
+// interface and IP version.
+func leaseFilePath(iface string, ipVersion ipVersion) string {
+	return path.Join(baseDhclientDir, leaseFileDir, fmt.Sprintf("dhclient.google-guest-agent.%s.%s.pid", iface, ipVersion.version))
+}
+
+// runDhclient obtains a lease with the provided IP version for the given
+// network interface. If release is set, this will release leases instead.
+func runDhclient(ctx context.Context, ipVersion ipVersion, nic string, release bool) error {
+	pidFile := pidFilePath(nic, ipVersion)
+	leaseFile := leaseFilePath(nic, ipVersion)
+
+	dhclientArgs := []string{ipVersion.dhclientArg, "-pf", pidFile, "-lf", leaseFile}
+
+	if release {
+		// Only release if the flag is set.
+		releaseArgs := append(dhclientArgs, "-r", nic)
+		if err := run.Quiet(ctx, "dhclient", releaseArgs...); err != nil {
+			return fmt.Errorf("error releasing lease for %s: %v", nic, err)
+		}
+	} else {
+		// Now obtain a lease if release is not set.
+		dhclientArgs = append(dhclientArgs, nic)
+		if err := run.Quiet(ctx, "dhclient", dhclientArgs...); err != nil {
+			return fmt.Errorf("error running dhclient for %s: %v", nic, err)
+		}
+	}
+	return nil
+}
+
+// paritionInterfaces creates 3 lists of interfaces
+// The first list contains interfaces for which to obtain an IPv4 lease.
+// The second list contains interfaces for which to obtain an IPv6 lease.
+// The third list contains interfaces for which to release their IPv6 lease.
+func partitionInterfaces(ctx context.Context, interfaces, ipv6Interfaces []string) ([]string, []string, []string, error) {
+	var obtainIpv4Interfaces []string
+	var obtainIpv6Interfaces []string
+	var releaseIpv6Interfaces []string
+
+	for i, iface := range interfaces {
+		if !shouldManageInterface(i == 0) {
+			// Do not setup anything for this interface to avoid duplicate processes.
+			continue
+		}
+
+		// Check for IPv4 interfaces for which to obtain a lease.
+		processExists, err := dhclientProcessExists(ctx, iface, ipv4)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if !processExists {
+			obtainIpv4Interfaces = append(obtainIpv4Interfaces, iface)
+		}
+
+		// Check for IPv6 interfaces for which to obtain a lease.
+		processExists, err = dhclientProcessExists(ctx, iface, ipv6)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		if slices.Contains(ipv6Interfaces, iface) && !processExists {
+			// Obtain a lease and spin up the DHClient process.
+			obtainIpv6Interfaces = append(obtainIpv6Interfaces, iface)
+		} else if !slices.Contains(ipv6Interfaces, iface) && processExists {
+			// Release the lease since the DHClient IPv6 process is running,
+			// but the interface is no longer IPv6.
+			releaseIpv6Interfaces = append(releaseIpv6Interfaces, iface)
+		}
+	}
+
+	return obtainIpv4Interfaces, obtainIpv6Interfaces, releaseIpv6Interfaces, nil
+}
+
+// dhclientProcessExists checks if a dhclient process for the provided
+// interface and IP version exists.
+func dhclientProcessExists(ctx context.Context, iface string, ipVersion ipVersion) (bool, error) {
+	processes, err := ps.Find(".*dhclient.*")
+	if err != nil {
+		return false, fmt.Errorf("error finding dhclient process: %v", err)
+	}
+
+	// Check for any dhclient process that contains the iface and IP version provided.
+	for _, process := range processes {
+		commandLine := process.CommandLine
+
+		containsInterface := slices.Contains(commandLine, iface)
+		containsProtocolArg := slices.Contains(commandLine, ipVersion.dhclientArg)
+
+		if containsInterface {
+			// IPv4 DHClient calls don't necessarily have the '-4' flag set.
+			if ipVersion == ipv6 {
+				return containsProtocolArg, nil
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Rollback releases all leases from DHClient, effectively undoing the dhclient configurations.
+func (n dhclient) Rollback(ctx context.Context, payload []metadata.NetworkInterfaces) error {
+	googleInterfaces, googleIpv6Interfaces := interfaceListsIpv4Ipv6(payload)
+
+	// Release all the interface leases from dhclient.
+	for _, iface := range googleInterfaces {
+		if err := runDhclient(ctx, ipv4, iface, true); err != nil {
+			return err
+		}
+	}
+	for _, iface := range googleIpv6Interfaces {
+		if err := runDhclient(ctx, ipv6, iface, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/google_guest_agent/network/manager/manager.go
+++ b/google_guest_agent/network/manager/manager.go
@@ -1,0 +1,356 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package manager is responsible for detecting the current network manager service, and
+// writing and rolling back appropriate configurations for each network manager service.
+package manager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/osinfo"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+)
+
+// Service is an interface for setting up network configurations
+// using different network managing services, such as systemd-networkd and wicked.
+type Service interface {
+	// IsManaging checks whether this network manager service is managing the provided interface.
+	IsManaging(ctx context.Context, iface string) (bool, error)
+
+	// Name is the name of the network manager service.
+	Name() string
+
+	// Setup writes the appropriate configurations for the network manager service for all
+	// non-primary network interfaces.
+	Setup(ctx context.Context, config *cfg.Sections, payload []metadata.NetworkInterfaces) error
+
+	// Rollback rolls back the changes created in Setup.
+	Rollback(ctx context.Context, payload []metadata.NetworkInterfaces) error
+}
+
+// osConfigRule describes matching rules for OS's, used for specifying either
+// network interfaces to ignore during setup or native config hookups.
+type osConfigRule struct {
+	// osNames is a list of OS's names matching the rule (as described by osInfo)
+	osNames []string
+
+	// majorVersions is a map of this OS's versions to ignore.
+	majorVersions map[int]bool
+
+	// action defines what action or exception to perform for this rule.
+	action osConfigAction
+}
+
+// osConfigAction defines the action to be taken in an osConfigRule.
+type osConfigAction struct {
+	// ignorePrimary determines whether to ignore the primary network interface.
+	ignorePrimary bool
+
+	// ignoreSecondary determines whether to ignore all non-primary network interfaces.
+	ignoreSecondary bool
+
+	// nativeOSConfig is a function pointer to the specific implementation that
+	// enables/disables OS management of the provided nics.
+	// NOTE: This will eventually be moved to the specific network manager implementation.
+	nativeOSConfig func(ctx context.Context, nic []string) error
+
+	// ignoreSetup indicates whether to ignore the rest of the network management setup.
+	// This is used with nativeOSConfig to determine if, after running the function, the
+	// agent should continue with the rest of the setup.
+	ignoreSetup bool
+}
+
+const (
+	googleComment = "# Added by Google Compute Engine Guest Agent."
+
+	// osConfigRuleAnyVersion applies a rule for any version of an OS.
+	osConfigRuleAnyVersion = -1
+)
+
+var (
+	// knownNetworkManagers contains the list of known network managers. This is
+	// used to determine the network manager service that is managing the primary
+	// network interface.
+	knownNetworkManagers []Service
+
+	// fallbackNetworkManager is the network manager service to be assumed if
+	// none of the known network managers returned true from IsManaging()
+	fallbackNetworkManager Service
+
+	// currManager is the Service implementation currently managing the interfaces.
+	currManager Service
+
+	// osRules lists the rules for applying interface configurations for primary
+	// and secondary interfaces.
+	osRules = []osConfigRule{
+		// Debian rules.
+		{
+			osNames: []string{"debian"},
+			majorVersions: map[int]bool{
+				10: true,
+				11: true,
+				12: true,
+			},
+			action: osConfigAction{
+				ignorePrimary:   true,
+				ignoreSecondary: true,
+			},
+		},
+		// RHEL rules.
+		{
+			osNames: []string{"rhel", "centos", "rocky"},
+			majorVersions: map[int]bool{
+				7: true,
+				8: true,
+				9: true,
+			},
+			action: osConfigAction{
+				ignorePrimary: true,
+			},
+		},
+		{
+			osNames: []string{"rhel", "centos", "rocky"},
+			majorVersions: map[int]bool{
+				osConfigRuleAnyVersion: true,
+			},
+			action: osConfigAction{
+				nativeOSConfig: rhelNativeOSConfig,
+			},
+		},
+		// SUSE rules
+		{
+			osNames: []string{"sles"},
+			majorVersions: map[int]bool{
+				osConfigRuleAnyVersion: true,
+			},
+			action: osConfigAction{
+				nativeOSConfig:  slesNativeOSConfig,
+				ignoreSetup:     true,
+				ignorePrimary:   true,
+				ignoreSecondary: true,
+			},
+		},
+		{
+			osNames: []string{"ubuntu"},
+			majorVersions: map[int]bool{
+				18: true,
+				20: true,
+				22: true,
+				23: true,
+			},
+			action: osConfigAction{
+				ignorePrimary: true,
+			},
+		},
+	}
+)
+
+// registerManager registers the provided network manager service to the list of known
+// network manager services. Fallback specifies whether the provided service should be
+// marked as a fallback service.
+func registerManager(s Service, fallback bool) {
+	if !fallback {
+		knownNetworkManagers = append(knownNetworkManagers, s)
+	} else {
+		if fallbackNetworkManager != nil {
+			panic("trying to register second fallback network manager")
+		} else {
+			fallbackNetworkManager = s
+		}
+	}
+}
+
+// detectNetworkManager detects the network manager managing the primary network interface.
+// This network manager will be used to set up primary and secondary network interfaces.
+func detectNetworkManager(ctx context.Context, iface string) (Service, error) {
+	logger.Infof("Detecting network manager...")
+
+	networkManagers := knownNetworkManagers
+	if fallbackNetworkManager != nil {
+		networkManagers = append(networkManagers, fallbackNetworkManager)
+	}
+
+	for _, curr := range networkManagers {
+		ok, err := curr.IsManaging(ctx, iface)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			logger.Infof("Network manager detected: %s", curr.Name())
+			return curr, nil
+		}
+	}
+	return nil, fmt.Errorf("no network manager impl found for %s", iface)
+}
+
+// findOSRule finds the osConfigRule that applies to the current system.
+func findOSRule(broadVersion bool) *osConfigRule {
+	osInfo := osinfo.Get()
+	for _, curr := range osRules {
+		if !slices.Contains(curr.osNames, osInfo.OS) {
+			continue
+		}
+
+		if broadVersion && curr.majorVersions[osConfigRuleAnyVersion] {
+			return &curr
+		}
+
+		if curr.majorVersions[osInfo.Version.Major] {
+			return &curr
+		}
+	}
+	return nil
+}
+
+// shouldManageInterface returns whether the guest agent should manage an interface
+// provided whether the interface of interest is the primary interface or not.
+func shouldManageInterface(isPrimary bool) bool {
+	rule := findOSRule(false)
+	if rule != nil {
+		if isPrimary {
+			return !rule.action.ignorePrimary
+		}
+		return !rule.action.ignoreSecondary
+	}
+	// Assume setup for anything not specified.
+	return true
+}
+
+// SetupInterfaces sets up all the network interfaces on the system, applying rules described
+// by osRules and using the native network manager service detected to be managing the primary
+// network interface.
+func SetupInterfaces(ctx context.Context, config *cfg.Sections, nics []metadata.NetworkInterfaces) error {
+	// User may have disabled network interface setup entirely.
+	if !config.NetworkInterfaces.Setup {
+		logger.Infof("network interface setup disabled, skipping...")
+		return nil
+	}
+
+	interfaces, err := interfaceNames(nics)
+	if err != nil {
+		return fmt.Errorf("error getting interface names: %v", err)
+	}
+	primaryInterface := interfaces[0]
+
+	// Apply the OS-specific rules.
+	osRule := findOSRule(true)
+	if osRule != nil && osRule.action.nativeOSConfig != nil {
+		logger.Infof("Found OS config rule. Running...")
+		if err = osRule.action.nativeOSConfig(ctx, interfaces); err != nil {
+			return fmt.Errorf("failed to disable OS nic management: %v", err)
+		}
+		// Don't run setup.
+		if osRule.action.ignoreSetup {
+			return nil
+		}
+	}
+
+	// Get the network manager.
+	nm, err := detectNetworkManager(ctx, primaryInterface)
+	if err != nil {
+		return fmt.Errorf("error detecting network manager service: %v", err)
+	}
+
+	// Since the manager is different, undo all the changes of the old manager.
+	if currManager != nil && nm != currManager {
+		if err = currManager.Rollback(ctx, nics); err != nil {
+			return fmt.Errorf("error rolling back config for %s: %v", currManager.Name(), err)
+		}
+	}
+
+	currManager = nm
+	if err = nm.Setup(ctx, config, nics); err != nil {
+		return fmt.Errorf("error setting up %s: %v", nm.Name(), err)
+	}
+	return nil
+}
+
+// slesNativeOSConfig writes on ifcfg file for each interface, then runs
+// `wicked ifup eth1 ... ethN`
+// NOTE: May remove entirely later on due to default configurations.
+func slesNativeOSConfig(ctx context.Context, interfaces []string) error {
+	var err error
+	var priority = 10100
+	for _, iface := range interfaces {
+		logger.Debugf("write enabling ifcfg-%s config", iface)
+
+		var ifcfg *os.File
+		ifcfg, err = os.Create("/etc/sysconfig/network/ifcfg-" + iface)
+		if err != nil {
+			return err
+		}
+		defer ifcfg.Close()
+
+		contents := []string{
+			googleComment,
+			"STARTMODE=hotplug",
+			// NOTE: 'dhcp' is the dhcp4+dhcp6 option.
+			"BOOTPROTO=dhcp",
+			fmt.Sprintf("DHCLIENT_ROUTE_PRIORITY=%d", priority),
+		}
+
+		_, err = ifcfg.WriteString(strings.Join(contents, "\n"))
+		if err != nil {
+			return err
+		}
+
+		priority += 100
+	}
+	args := append([]string{"ifup", "--timeout", "1"}, interfaces...)
+	return run.Quiet(ctx, "/usr/sbin/wicked", args...)
+}
+
+// rhelNativeOSConfig writes an ifcfg file with DHCP and NetworkManager disabled
+// to all secondary nics.
+func rhelNativeOSConfig(ctx context.Context, interfaces []string) error {
+	for _, curr := range interfaces[1:] {
+		if err := writeRHELIfcfg(curr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeRHELIfcfg writes the ifcfg file for the specified interface.
+func writeRHELIfcfg(iface string) error {
+	logger.Debugf("write disabling ifcfg-%s config", iface)
+	filename := "/etc/sysconfig/network-scripts/ifcfg-" + iface
+	ifcfg, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err == nil {
+		defer ifcfg.Close()
+		contents := []string{
+			googleComment,
+			fmt.Sprintf("DEVICE=%s", iface),
+			"BOOTPROTO=none",
+			"DEFROUTE=no",
+			"IPV6INIT=no",
+			"NM_CONTROLLED=no",
+			"NOZEROCONF=yes",
+		}
+		_, err = ifcfg.WriteString(strings.Join(contents, "\n"))
+		return err
+	}
+	if os.IsExist(err) {
+		return nil
+	}
+	return err
+}

--- a/google_guest_agent/network/manager/manager_test.go
+++ b/google_guest_agent/network/manager/manager_test.go
@@ -1,0 +1,177 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package manager is responsible for detecting the current network manager service, and
+// writing and rolling back appropriate configurations for each network manager service.
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
+)
+
+const (
+	// Values for determining behavior of mockService's IsManaging()
+	valueFalse = 0
+	valueTrue  = 1
+	valueErr   = 2
+)
+
+// Create mock service.
+type mockService struct {
+	isFallback bool
+	isManaging int
+}
+
+// Name implements the Service interface.
+func (n mockService) Name() string {
+	if n.isFallback {
+		return "fallback"
+	}
+	return "service"
+}
+
+// IsManaging implements the Service interface.
+func (n mockService) IsManaging(ctx context.Context, iface string) (bool, error) {
+	if n.isManaging == valueErr {
+		return false, fmt.Errorf("mock error")
+	}
+	return n.isManaging == valueTrue, nil
+}
+
+// Setup implements the Service interface.
+func (n mockService) Setup(ctx context.Context, config *cfg.Sections, payload []metadata.NetworkInterfaces) error {
+	return nil
+}
+
+// Rollback implements the Service interface.
+func (n mockService) Rollback(ctx context.Context, payload []metadata.NetworkInterfaces) error {
+	return nil
+}
+
+// managerTestSetup does pre-test setup steps.
+func managerTestSetup() {
+	// Clear the known network managers and fallbacks.
+	knownNetworkManagers = []Service{}
+	fallbackNetworkManager = nil
+}
+
+// TestDetectNetworkManager tests whether DetectNetworkManager()
+// correctly returns a network manager that's not the fallback.
+func TestDetectNetworkManager(t *testing.T) {
+	managerTestSetup()
+	registerManager(mockService{
+		isFallback: false,
+		isManaging: valueTrue,
+	}, false)
+	registerManager(mockService{
+		isFallback: true,
+		isManaging: valueFalse,
+	}, false)
+	var expectedManager = knownNetworkManagers[0]
+
+	s, err := detectNetworkManager(context.Background(), "iface")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if s.Name() != expectedManager.Name() {
+		t.Fatalf("did not get expected network manager: got %s, wanted %s", s.Name(), expectedManager.Name())
+	}
+}
+
+// TestDetectNetworkManagerNoManager tests whether DetectNetworkManager
+// correctly errors if no suitable network managers are found.
+func TestDetectNetworkManagerNoManager(t *testing.T) {
+	managerTestSetup()
+	registerManager(mockService{
+		isFallback: false,
+		isManaging: valueFalse,
+	}, false)
+	registerManager(mockService{
+		isFallback: true,
+		isManaging: valueFalse,
+	}, true)
+
+	_, err := detectNetworkManager(context.Background(), "iface")
+	if err == nil {
+		t.Fatalf("DetectNetworkManager() did not return an error when it should have")
+	}
+
+	var expectedError = "no network manager impl found for iface"
+	if err.Error() != expectedError {
+		t.Fatalf("error did not match expected error message: \nExpected: %v,\nActual: %s", expectedError, err.Error())
+	}
+}
+
+// TestDetectNetworkManagerError tests whether DetectNetworkManager()
+// correctly throws an error if IsManaging() errors.
+func TestDetectNetworkManagerError(t *testing.T) {
+	managerTestSetup()
+	registerManager(mockService{
+		isFallback: false,
+		isManaging: valueErr,
+	}, false)
+	registerManager(mockService{
+		isFallback: true,
+		isManaging: valueTrue,
+	}, true)
+
+	_, err := detectNetworkManager(context.Background(), "iface")
+	if err == nil {
+		t.Fatalf("DetectNetworkManager() did not return an error when it should have")
+	}
+
+	var expectedError = "mock error"
+	if err.Error() != expectedError {
+		t.Fatalf("error did not match expected error message: \nExpected: %v,\nActual: %s", expectedError, err.Error())
+	}
+}
+
+// TestDetectNetworkManagerFallback tests whether DetectNetworkManager
+// correctly returns the fallback if all other network manager services
+// are not detected.
+func TestDetectNetworkManagerFallback(t *testing.T) {
+	managerTestSetup()
+	registerManager(mockService{
+		isFallback: false,
+		isManaging: valueFalse,
+	}, false)
+	registerManager(mockService{
+		isFallback: false,
+		isManaging: valueFalse,
+	}, false)
+	registerManager(mockService{
+		isFallback: false,
+		isManaging: valueFalse,
+	}, false)
+	registerManager(mockService{
+		isFallback: true,
+		isManaging: valueTrue,
+	}, true)
+
+	s, err := detectNetworkManager(context.Background(), "iface")
+	if err != nil {
+		t.Fatalf("DetectNetworkManager() incorrectly returned an error: %v", err)
+	}
+
+	var expectedName = "fallback"
+	if s.Name() != expectedName {
+		t.Fatalf("DetectNetworkManager() did not return correct manager: Expected: %v, Actual: %v", expectedName, s.Name())
+	}
+}

--- a/google_guest_agent/network/manager/systemd_networkd_linux.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux.go
@@ -79,6 +79,22 @@ type systemdMatchConfig struct {
 type systemdNetworkConfig struct {
 	// DHCP determines the ipv4/ipv6 protocol version for use with dhcp.
 	DHCP string
+
+	// DNSDefaultRoute is used to determine if the link's configured DNS servers are
+	// used for resolving domain names that do not match any link's domain.
+	DNSDefaultRoute bool
+}
+
+// systemdDHCPConfig contains the dhcp specific configurations for a
+// systemd network configuration.
+type systemdDHCPConfig struct {
+	// RoutesToDNS defines if routes to the DNS servers received from the DHCP
+	// shoud be configured/installed.
+	RoutesToDNS bool
+
+	// RoutesToNTP defines if routes to the NTP servers received from the DHCP
+	// shoud be configured/installed.
+	RoutesToNTP bool
 }
 
 // systemdConfig wraps the interface configuration for systemd-networkd.
@@ -92,6 +108,12 @@ type systemdConfig struct {
 
 	// Network is the systemd-networkd ini file's [Network] section.
 	Network systemdNetworkConfig
+
+	// DHCPv4 is the systemd-networkd ini file's [DHCPv4] section.
+	DHCPv4 systemdDHCPConfig
+
+	// DHCPv6 is the systemd-networkd ini file's [DHCPv4] section.
+	DHCPv6 systemdDHCPConfig
 }
 
 // Name returns the name of the network manager service.
@@ -176,7 +198,16 @@ func (n systemdNetworkd) Setup(ctx context.Context, config *cfg.Sections, payloa
 				Name: iface,
 			},
 			Network: systemdNetworkConfig{
-				DHCP: dhcp,
+				DHCP:            dhcp,
+				DNSDefaultRoute: false,
+			},
+			DHCPv4: systemdDHCPConfig{
+				RoutesToDNS: false,
+				RoutesToNTP: false,
+			},
+			DHCPv6: systemdDHCPConfig{
+				RoutesToDNS: false,
+				RoutesToNTP: false,
 			},
 		}
 

--- a/google_guest_agent/network/manager/systemd_networkd_linux.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux.go
@@ -1,0 +1,242 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package manager is responsible for detecting the current network manager service, and
+// writing and rolling back appropriate configurations for each network manager service.
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+	"github.com/go-ini/ini"
+)
+
+const (
+	// minSupportedVersion is the version from which we start supporting
+	// systemd-networkd.
+	minSupportedVersion = 253
+)
+
+type systemdNetworkd struct {
+	// configDir determines where the agent writes its configuration files.
+	configDir string
+
+	// networkCtlKeys helps with compatibility with different versions of
+	// systemd, where the desired status key can be different.
+	networkCtlKeys []string
+
+	// priority dictates the priority with which guest-agent should write
+	// the configuration files.
+	priority string
+}
+
+// init adds this network manager service to the list of known network managers.
+func init() {
+	registerManager(&systemdNetworkd{
+		configDir:      "/usr/lib/systemd/network",
+		networkCtlKeys: []string{"AdministrativeState", "SetupState"},
+		priority:       "1",
+	}, false)
+}
+
+// guestAgent contains the guest-agent control flags/data.
+type guestAgent struct {
+	// ManagedByGuestAgent determines if a given configuration was written and is
+	// managed by guest-agent.
+	ManagedByGuestAgent bool
+}
+
+// systemdMatchConfig contains the systemd-networkd's interface matching criteria.
+type systemdMatchConfig struct {
+	// Name is the matching criteria based on the interface name.
+	Name string
+}
+
+// systemdNetworkConfig contains the actual interface rule's configuration.
+type systemdNetworkConfig struct {
+	// DHCP determines the ipv4/ipv6 protocol version for use with dhcp.
+	DHCP string
+}
+
+// systemdConfig wraps the interface configuration for systemd-networkd.
+// Ultimately the structure will be unmarshalled into a .ini file.
+type systemdConfig struct {
+	// GuestAgent is a section containing guest-agent control flags/data.
+	GuestAgent guestAgent
+
+	// Match is the systemd-networkd ini file's [Match] section.
+	Match systemdMatchConfig
+
+	// Network is the systemd-networkd ini file's [Network] section.
+	Network systemdNetworkConfig
+}
+
+// Name returns the name of the network manager service.
+func (n systemdNetworkd) Name() string {
+	return "systemd-networkd"
+}
+
+// IsManaging checks whether systemd-networkd is managing the provided interface.
+// This first checks if the systemd-networkd service is running, then uses networkctl
+// to check if systemd-networkd is managing or has configured the provided interface.
+func (n systemdNetworkd) IsManaging(ctx context.Context, iface string) (bool, error) {
+	// Check the version.
+	if _, err := exec.LookPath("networkctl"); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error looking up networkctl path: %v", err)
+	}
+	res := run.WithOutput(ctx, "networkctl", "--version")
+	if res.ExitCode != 0 {
+		return false, fmt.Errorf("error checking networkctl version: %v", res.StdErr)
+	}
+	// The version is the second field of the first line.
+	versionString := strings.Split(strings.Split(res.StdOut, "\n")[0], " ")[1]
+	version, err := strconv.Atoi(versionString)
+	if err != nil {
+		return false, fmt.Errorf("error parsing systemd version: %v", err)
+	}
+	if version < minSupportedVersion {
+		logger.Infof("systemd-networkd version %v not supported: minimum %v required", version, minSupportedVersion)
+		return false, nil
+	}
+
+	// First check if the service is running.
+	res = run.WithOutput(ctx, "systemctl", "is-active", "systemd-networkd.service")
+	if res.ExitCode != 0 {
+		return false, nil
+	}
+
+	// Check systemd network configuration.
+	res = run.WithOutput(ctx, "/bin/sh", "-c", fmt.Sprintf("networkctl status %s --json=short", iface))
+	if res.ExitCode != 0 {
+		return false, fmt.Errorf("failed to check systemd-networkd network status: %v", res.StdErr)
+	}
+
+	interfaceStatus := make(map[string]any)
+
+	if err = json.Unmarshal([]byte(res.StdOut), &interfaceStatus); err != nil {
+		return false, fmt.Errorf("failed to unmarshal interface status: %v", err)
+	}
+
+	for _, statusKey := range n.networkCtlKeys {
+		state, found := interfaceStatus[statusKey]
+		if !found {
+			continue
+		}
+
+		return state == "configured", nil
+	}
+	return false, fmt.Errorf("could not determine interface state, one of %v was not present", n.networkCtlKeys)
+}
+
+// Setup sets up the non-primary network interfaces for systemd-networkd by writing
+// configuration files to the specified configuration directory.
+func (n systemdNetworkd) Setup(ctx context.Context, config *cfg.Sections, payload []metadata.NetworkInterfaces) error {
+	// Create a network configuration file with default configurations for each network interface.
+	googleInterfaces, googleIpv6Interfaces := interfaceListsIpv4Ipv6(payload)
+	for _, iface := range googleInterfaces {
+		logger.Debugf("write %s network config for %s", n.Name(), iface)
+
+		var dhcp = "ipv4"
+		if slices.Contains(googleIpv6Interfaces, iface) {
+			dhcp = "yes"
+		}
+
+		// Create and setup ini file.
+		data := systemdConfig{
+			GuestAgent: guestAgent{
+				ManagedByGuestAgent: true,
+			},
+			Match: systemdMatchConfig{
+				Name: iface,
+			},
+			Network: systemdNetworkConfig{
+				DHCP: dhcp,
+			},
+		}
+
+		config := ini.Empty()
+		if err := ini.ReflectFrom(config, &data); err != nil {
+			return fmt.Errorf("error creating config ini: %v", err)
+		}
+
+		// Priority is lexicographically sorted in ascending order by file name. So a configuration
+		// starting with '1-' takes priority over a configuration file starting with '10-'. Setting
+		// a priority of 1 allows the guest-agent to override any existing default configurations
+		// while also allowing users the freedom of using priorities of '0...' to override the
+		// agent's own configurations.
+		configPath := fmt.Sprintf("%s/%s-%s-google-guest-agent.network", n.configDir, n.priority, iface)
+		if err := config.SaveTo(configPath); err != nil {
+			return fmt.Errorf("error saving config for %s: %v", iface, err)
+		}
+	}
+	// Avoid restarting systemd-networkd.
+	if err := run.Quiet(ctx, "networkctl", "reload"); err != nil {
+		return fmt.Errorf("error reloading systemd-networkd network configs: %v", err)
+	}
+	return nil
+}
+
+// Rollback deletes the configuration files created by the agent for systemd-networkd.
+func (n systemdNetworkd) Rollback(ctx context.Context, payload []metadata.NetworkInterfaces) error {
+	logger.Infof("rolling back changes for %s", n.Name())
+	interfaces, err := interfaceNames(payload)
+	if err != nil {
+		return fmt.Errorf("failed to get list of interface names: %v", err)
+	}
+
+	for _, iface := range interfaces[1:] {
+		// Find expected files.
+		configFile := fmt.Sprintf("%s/%s-%s-google-guest-agent.network", n.configDir, n.priority, iface)
+		logger.Debugf("checking for %s", configFile)
+		opts := ini.LoadOptions{
+			Loose:       true,
+			Insensitive: true,
+		}
+		config, err := ini.LoadSources(opts, configFile)
+		if err != nil {
+			// Could not find the file.
+			continue
+		}
+
+		// Parse the config ini.
+		sections := new(systemdConfig)
+		if err = config.MapTo(sections); err != nil {
+			return fmt.Errorf("error parsing config ini: %v", err)
+		}
+
+		// Check that the guest section exists and the key is set to true.
+		if sections.GuestAgent.ManagedByGuestAgent {
+			logger.Debugf("removing %s", configFile)
+			if err = os.Remove(configFile); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/google_guest_agent/ps/ps.go
+++ b/google_guest_agent/ps/ps.go
@@ -1,0 +1,29 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package ps provides a way to find a process in linux without using the ps CLI tool.
+package ps
+
+// Process describes an OS process.
+type Process struct {
+	// Pid is the process id.
+	Pid int
+
+	// Exe is the path of the processes executable file.
+	Exe string
+
+	// CommandLine contains the processes executable path and its command
+	// line arguments (honoring the order they were presented when executed).
+	CommandLine []string
+}

--- a/google_guest_agent/ps/ps_linux.go
+++ b/google_guest_agent/ps/ps_linux.go
@@ -1,0 +1,108 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ps
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+)
+
+const (
+	// defaultLinuxProcDir is the default location of proc filesystem mount point in
+	// a linux system.
+	defaultLinuxProcDir = "/proc/"
+)
+
+var (
+	// linuxProcDir is the location of proc filesystem mout point currently set up
+	// in the current execution. Unit tests may want to adjust it in order to simulate
+	// the target system.
+	linuxProcDir = defaultLinuxProcDir
+)
+
+// Find finds all processes with the executable path matching the provided regex.
+func Find(exeMatch string) ([]Process, error) {
+	var result []Process
+
+	procExpression, err := regexp.Compile("^[0-9]*$")
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile process dir expression: %+v", err)
+	}
+
+	exeExpression, err := regexp.Compile(exeMatch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile process exec matching expression: %+v", err)
+	}
+
+	files, err := os.ReadDir(linuxProcDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read linux proc dir: %+v", err)
+	}
+
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+
+		if !procExpression.MatchString(file.Name()) {
+			continue
+		}
+
+		processRootDir := path.Join(linuxProcDir, file.Name())
+		exeLinkPath := path.Join(processRootDir, "exe")
+
+		exePath, err := os.Readlink(exeLinkPath)
+		if err != nil {
+			continue
+		}
+
+		if !exeExpression.MatchString(exePath) {
+			continue
+		}
+
+		cmdlinePath := path.Join(processRootDir, "cmdline")
+		dat, err := os.ReadFile(cmdlinePath)
+		if err != nil {
+			return nil, fmt.Errorf("error reading cmdline file: %v", err)
+		}
+
+		var commandLine []string
+		var token []byte
+		for _, curr := range dat {
+			if curr == 0 {
+				commandLine = append(commandLine, string(token))
+				token = nil
+			} else {
+				token = append(token, curr)
+			}
+		}
+
+		pid, err := strconv.Atoi(file.Name())
+		if err != nil {
+			return nil, fmt.Errorf("error parsing PID: %v", err)
+		}
+
+		result = append(result, Process{
+			Pid:         pid,
+			Exe:         exePath,
+			CommandLine: commandLine,
+		})
+	}
+
+	return result, nil
+}

--- a/google_guest_agent/ps/ps_linux_test.go
+++ b/google_guest_agent/ps/ps_linux_test.go
@@ -1,0 +1,157 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ps
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+)
+
+// Setup a fake process directory.
+func setupProc(t *testing.T, entries []*Process) {
+	t.Helper()
+	linuxProcDir = path.Join(t.TempDir(), "proc")
+
+	if err := os.MkdirAll(linuxProcDir, 0755); err != nil {
+		t.Fatalf("failed to make mocked proc dir: %+v", err)
+	}
+
+	if entries == nil {
+		return
+	}
+
+	for _, curr := range entries {
+		procDir := path.Join(linuxProcDir, fmt.Sprintf("%d", curr.Pid))
+		if err := os.MkdirAll(procDir, 0755); err != nil {
+			t.Fatalf("failed to make process dir: %+v", err)
+		}
+
+		// randomFilePath is the path of a random/unknown file in the processe's dir.
+		randomFilePath := path.Join(procDir, "random-file")
+		err := os.WriteFile(path.Join(randomFilePath), []byte("random\n"), 0644)
+		if err != nil {
+			t.Fatalf("failed to write random proc file: %+v", err)
+		}
+
+		// randomDirPath is the path of a random/unknown dir in the processe's dir.
+		randomDirPath := path.Join(procDir, "random-dir")
+		if err := os.MkdirAll(randomDirPath, 0755); err != nil {
+			t.Fatalf("failed to make random dir in the proc dir: %+v", err)
+		}
+
+		if curr.Exe != "" {
+			exeLinkPath := path.Join(procDir, "exe")
+			if err := os.Symlink(curr.Exe, exeLinkPath); err != nil {
+				t.Fatalf("failed to create exe sym link: %+v", err)
+			}
+		}
+
+		if len(curr.CommandLine) > 0 {
+			cmdlineFilePath := path.Join(procDir, "cmdline")
+
+			var data []byte
+			for _, line := range curr.CommandLine {
+				data = append(data, []byte(line)...)
+				data = append(data, 0)
+			}
+
+			err := os.WriteFile(cmdlineFilePath, data, 0644)
+			if err != nil {
+				t.Fatalf("failed to write random proc file: %+v", err)
+			}
+		}
+	}
+}
+
+// Undo the changes made by each test.
+func tearDown(t *testing.T) {
+	t.Helper()
+	linuxProcDir = defaultLinuxProcDir
+}
+
+// TestEmptyProcDir tests if Find correctly returns nil if the process directory is empty.
+func TestEmptyProcDir(t *testing.T) {
+	setupProc(t, nil)
+	procs, err := Find(".*dhclient.*")
+	if err != nil {
+		t.Fatalf("ps.Find() returned error: %+v, expected: nil", err)
+	}
+
+	if procs != nil {
+		t.Fatalf("ps.Find() returned: %+v, expected: nil", procs)
+	}
+	tearDown(t)
+}
+
+// TestMalformedExe tests if Find correctly returns nil if the process contains a bad exe.
+func TestMalformedExe(t *testing.T) {
+	procs := []*Process{
+		&Process{1, "", nil},
+	}
+	setupProc(t, procs)
+
+	res, err := Find(".*dhclient.*")
+	if err != nil {
+		t.Fatalf("ps.Find() returned error: %+v, expected: nil", err)
+	}
+
+	if res != nil {
+		t.Fatalf("ps.Find() returned: %+v, expected: nil", res)
+	}
+	tearDown(t)
+}
+
+// TestFind tests whether Find() can find existing processes, and that it can
+// return a nil response if the process does not exist.
+func TestFind(t *testing.T) {
+	tests := []struct {
+		success bool
+		expr    string
+	}{
+		{true, ".*dhclient.*"},
+		{true, ".*google_guest_agent.*"},
+		{false, ".*dhclientx.*"},
+		{false, ".*google_guest_agentx.*"},
+	}
+
+	procs := []*Process{
+		&Process{1, "/usr/bin/dhclient", []string{"dhclient", "eth0"}},
+		&Process{2, "/usr/bin/google_guest_agent", []string{"google_guest_agent"}},
+	}
+	setupProc(t, procs)
+
+	for i, curr := range tests {
+		t.Run(fmt.Sprintf("test-%d-%s", i, curr.expr), func(t *testing.T) {
+			res, err := Find(curr.expr)
+			if curr.success {
+				if err != nil {
+					t.Errorf("ps.Find() returned error: %+v, expected: nil", err)
+				}
+
+				if res == nil {
+					t.Fatalf("ps.Find() returned: nil, expected: non-nil")
+				}
+			} else {
+				if res != nil {
+					t.Fatalf("ps.Find() returned: non-nil, expected: nil")
+				}
+			}
+		})
+	}
+
+	tearDown(t)
+}

--- a/google_guest_agent/ps/ps_windows.go
+++ b/google_guest_agent/ps/ps_windows.go
@@ -1,0 +1,21 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ps
+
+// Find finds all processes with the executable path matching the provided regex.
+// Note: not yet implemented for windows.
+func Find(exeMatch string) ([]Process, error) {
+	panic("ps.Find() is not yet implemented for windows")
+}


### PR DESCRIPTION
This is part of the ongoing work to deprecate DHClient. The main priority currently is utilizing `systemd-networkd`, since Ubuntu will be removing `dhclient` after their upcoming freeze at the end of January. The other network management services, such as `wicked` and `NetworkManager` will come later.

Currently, this will do the following
- If `dhclient` is found on the system, we continue using `dhclient` for network interface configuration.
- If not, then we use `systemd-networkd`.