### PR TITLE
Don't override version on metadata script runner with hardcoded constant

### DIFF
--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -48,7 +48,6 @@ const (
 	storageURL     = "storage.googleapis.com"
 	bucket         = "([a-z0-9][-_.a-z0-9]*)"
 	object         = "(.+)"
-	version        = "dev"
 	defaultTimeout = 20 * time.Second
 )
 
@@ -82,7 +81,8 @@ var (
 
 	testStorageClient *storage.Client
 
-	client metadata.MDSClientInterface
+	client  metadata.MDSClientInterface
+	version string
 )
 
 func init() {


### PR DESCRIPTION
Version is set during package build -
* [RPM spec](https://github.com/GoogleCloudPlatform/guest-agent/blob/main/packaging/google-guest-agent.spec#L44)
* [APT spec](https://github.com/GoogleCloudPlatform/guest-agent/blob/main/packaging/debian/rules#L30)
* [Goo spec](https://github.com/GoogleCloudPlatform/guest-agent/blob/main/packaging/googet/google-compute-engine-metadata-scripts.goospec#L45)

Don't override it with hardcoded constant.