### PR TITLE
Create NetworkManager implementation

### DIFF
--- a/google_guest_agent/network/manager/manager_test.go
+++ b/google_guest_agent/network/manager/manager_test.go
@@ -234,9 +234,6 @@ func TestFindOSRule(t *testing.T) {
 		// rules are mock OSConfig rules.
 		rules []osConfigRule
 
-		// broadVersion indicates whether to call findOSRule() using broad versions.
-		broadVersion bool
-
 		// expectedNil indicates to expect a nil return when set to true.
 		expectedNil bool
 	}{
@@ -252,23 +249,7 @@ func TestFindOSRule(t *testing.T) {
 					action: osConfigAction{},
 				},
 			},
-			broadVersion: false,
-			expectedNil:  false,
-		},
-		// ignoreRule broad version exists.
-		{
-			name: "ignore-exist-broad",
-			rules: []osConfigRule{
-				{
-					osNames: []string{"test"},
-					majorVersions: map[int]bool{
-						osConfigRuleAnyVersion: true,
-					},
-					action: osConfigAction{},
-				},
-			},
-			broadVersion: true,
-			expectedNil:  false,
+			expectedNil: false,
 		},
 		// ignoreRule does not exist.
 		{
@@ -282,53 +263,7 @@ func TestFindOSRule(t *testing.T) {
 					action: osConfigAction{},
 				},
 			},
-			broadVersion: false,
-			expectedNil:  true,
-		},
-		// ignoreRule broadVersion does not exist.
-		{
-			name: "ignore-no-exist-broad",
-			rules: []osConfigRule{
-				{
-					osNames: []string{"non-test"},
-					majorVersions: map[int]bool{
-						osConfigRuleAnyVersion: true,
-					},
-					action: osConfigAction{},
-				},
-			},
-			broadVersion: true,
-			expectedNil:  true,
-		},
-		// ignoreRule non-broadVersion exists, but we want broad version.
-		{
-			name: "ignore-no-exist-broad-nonbroad-exist",
-			rules: []osConfigRule{
-				{
-					osNames: []string{"test"},
-					majorVersions: map[int]bool{
-						testOSVersion: true,
-					},
-					action: osConfigAction{},
-				},
-			},
-			broadVersion: true,
-			expectedNil:  true,
-		},
-		// ignoreRule broadVersion exists, but we want non-broad version.
-		{
-			name: "ignore-no-exist-broad-exist",
-			rules: []osConfigRule{
-				{
-					osNames: []string{"test"},
-					majorVersions: map[int]bool{
-						osConfigRuleAnyVersion: true,
-					},
-					action: osConfigAction{},
-				},
-			},
-			broadVersion: false,
-			expectedNil:  true,
+			expectedNil: true,
 		},
 	}
 
@@ -338,7 +273,7 @@ func TestFindOSRule(t *testing.T) {
 			managerTestSetup()
 
 			osRules = test.rules
-			osRule := findOSRule(test.broadVersion)
+			osRule := findOSRule()
 
 			if osRule == nil && !test.expectedNil {
 				t.Errorf("findOSRule() returned nil when non-nil expected")

--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -1,0 +1,247 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package manager is responsible for detecting the current network manager service, and
+// writing and rolling back appropriate configurations for each network manager service.
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
+	"github.com/GoogleCloudPlatform/guest-agent/metadata"
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+	"github.com/go-ini/ini"
+)
+
+const (
+	defaultNetworkManagerConfigDir = "/etc/NetworkManager/system-connections"
+)
+
+// nmConnectionSection is the connection section of NetworkManager's keyfile.
+type nmConnectionSection struct {
+	// InterfaceName is the name of the interface to configure.
+	InterfaceName string `ini:"interface-name"`
+
+	// ID is the unique ID for this connection.
+	ID string `ini:"id"`
+
+	// ConnType is the type of connection (i.e. ethernet).
+	ConnType string `ini:"type"`
+}
+
+// nmIpv4Section is the ipv4 section of NetworkManager's keyfile.
+type nmIpv4Section struct {
+	// Method is the IP configuration method. Supports "auto", "manual", and "link-local".
+	Method string
+}
+
+// nmIpv6Section is the ipv6 section of NetworkManager's keyfile.
+type nmIpv6Section struct {
+	// Method is the IP configuration method. Supports "auto", "manual", and "link-local".
+	Method string
+}
+
+// nmConfig is a wrapper containing all the sections for the NetworkManager keyfile.
+type nmConfig struct {
+	// GuestAgent is the 'guest-agent' section.
+	GuestAgent guestAgentSection `ini:"guest-agent"`
+
+	// Connection is the connection section.
+	Connection nmConnectionSection `ini:"connection"`
+
+	// Ipv4 is the ipv4 section.
+	Ipv4 nmIpv4Section `ini:"ipv4"`
+
+	// Ipv6 is the ipv6 section.
+	Ipv6 nmIpv6Section `ini:"ipv6"`
+}
+
+// networkManager implements the manager.Service interface for NetworkManager.
+type networkManager struct {
+	// configDir is the directory to which to write the configuration files.
+	configDir string
+}
+
+// init registers this network manager service to the list of known network managers.
+func init() {
+	registerManager(&networkManager{
+		configDir: defaultNetworkManagerConfigDir,
+	}, false)
+}
+
+// Name is the name of this network manager service.
+func (n networkManager) Name() string {
+	return "NetworkManager"
+}
+
+// IsManaging checks if NetworkManager is managing the provided interface.
+func (n networkManager) IsManaging(ctx context.Context, iface string) (bool, error) {
+	// Check whether NetworkManager.service is active.
+	if err := run.Quiet(ctx, "systemctl", "is-active", "NetworkManager.service"); err != nil {
+		return false, nil
+	}
+
+	// Check for existence of nmcli. Without nmcli, the agent cannot tell NetworkManager
+	// to reload the configs for its connections.
+	if _, err := execLookPath("nmcli"); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error checking for nmcli: %v", err)
+	}
+
+	// Use nmcli to check status of provided  interface.
+	res := run.WithOutput(ctx, "nmcli", "-t", "-f", "DEVICE,STATE", "dev", "status")
+	if res.ExitCode != 0 {
+		return false, fmt.Errorf("error checking status of devices on NetworkManager: %v", res.StdErr)
+	}
+
+	output := res.StdOut
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, iface) {
+			fields := strings.Split(line, ":")
+			return fields[1] == "connected", nil
+		}
+	}
+	return false, nil
+}
+
+// Setup sets up the necessary configurations for NetworkManager.
+func (n networkManager) Setup(ctx context.Context, config *cfg.Sections, payload []metadata.NetworkInterfaces) error {
+	ifaces, err := interfaceNames(payload)
+	if err != nil {
+		return fmt.Errorf("error getting interfaces: %v", err)
+	}
+
+	connections, err := n.writeNetworkManagerConfigs(ifaces)
+	if err != nil {
+		return fmt.Errorf("error writing NetworkManager connection configs: %v", err)
+	}
+
+	// This is primarily for RHEL-7 compatibility. Without reloading, attempting to
+	// enable the connections in the next step returns a "mismatched interface" error.
+	if err := run.Quiet(ctx, "nmcli", "conn", "reload"); err != nil {
+		return fmt.Errorf("error reloading NetworkManager config cache: %v", err)
+	}
+
+	// Enable the new connections.
+	for _, conn := range connections {
+		if err = run.Quiet(ctx, "nmcli", "conn", "up", "id", conn); err != nil {
+			return fmt.Errorf("error enabling connection %s: %v", conn, err)
+		}
+	}
+	return nil
+}
+
+// networkManagerConfigFilePath gets the config file path for the provided interface.
+func (n networkManager) networkManagerConfigFilePath(iface string) string {
+	return path.Join(n.configDir, fmt.Sprintf("google-guest-agent-%s.nmconnection", iface))
+}
+
+// writeNetworkManagerConfigs writes the configuration files for NetworkManager.
+func (n networkManager) writeNetworkManagerConfigs(ifaces []string) ([]string, error) {
+	var connections []string
+
+	for _, iface := range ifaces {
+		logger.Debugf("writing nmconnection file for %s", iface)
+
+		configFilePath := n.networkManagerConfigFilePath(iface)
+		connID := fmt.Sprintf("google-guest-agent-%s", iface)
+
+		opts := ini.LoadOptions{
+			Insensitive: true,
+		}
+		configFile := ini.Empty(opts)
+
+		// Create the ini file.
+		config := nmConfig{
+			GuestAgent: guestAgentSection{
+				Managed: true,
+			},
+			Connection: nmConnectionSection{
+				InterfaceName: iface,
+				ID:            connID,
+				ConnType:      "ethernet",
+			},
+			Ipv4: nmIpv4Section{
+				Method: "auto",
+			},
+			Ipv6: nmIpv6Section{
+				Method: "auto",
+			},
+		}
+
+		if err := configFile.ReflectFrom(&config); err != nil {
+			return []string{}, fmt.Errorf("error creating config ini: %v", err)
+		}
+
+		// Save the config.
+		if err := configFile.SaveTo(configFilePath); err != nil {
+			return []string{}, fmt.Errorf("error saving connection config for %s: %v", iface, err)
+		}
+
+		// The permissions need to be 600 in order for nmcli to load and use the file correctly.
+		if err := os.Chmod(configFilePath, 0600); err != nil {
+			return []string{}, fmt.Errorf("error updating permissions for %s connection config: %v", iface, err)
+		}
+
+		connections = append(connections, connID)
+	}
+	return connections, nil
+}
+
+// Rollback deletes the configurations created by Setup().
+func (n networkManager) Rollback(ctx context.Context, payload []metadata.NetworkInterfaces) error {
+	ifaces, err := interfaceNames(payload)
+	if err != nil {
+		return fmt.Errorf("error getting interfaces: %v", err)
+	}
+
+	for _, iface := range ifaces {
+		configFilePath := path.Join(n.configDir, fmt.Sprintf("google-guest-agent-%s.nmconnection", iface))
+		opts := ini.LoadOptions{
+			Loose:       true,
+			Insensitive: true,
+		}
+
+		// See if it exists.
+		configFile, err := ini.LoadSources(opts, configFilePath)
+		if err != nil {
+			return fmt.Errorf("error loading config file: %v", err)
+		}
+
+		config := new(nmConfig)
+		if err = configFile.MapTo(config); err != nil {
+			return fmt.Errorf("error parsing config ini for %s: %v", iface, err)
+		}
+
+		if config.GuestAgent.Managed {
+			logger.Debugf("removing %s", configFilePath)
+
+			if err = os.Remove(configFilePath); err != nil {
+				return fmt.Errorf("error deleting config file for %s: %v", iface, err)
+			}
+		}
+	}
+	return nil
+}

--- a/google_guest_agent/network/manager/network_manager_linux_test.go
+++ b/google_guest_agent/network/manager/network_manager_linux_test.go
@@ -1,0 +1,400 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package manager is responsible for detecting the current network manager service, and
+// writing and rolling back appropriate configurations for each network manager service.
+package manager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
+	"github.com/go-ini/ini"
+)
+
+var (
+	// testNetworkManager is the test NetworkManager implementation to use for the test.
+	testNetworkManager = &networkManager{}
+)
+
+// networkManagerMockRunner is the mock run client for this test.
+type nmMockRunner struct {
+	// networkServiceValue is the return value of 'systemctl status network.service'.
+	networkServiceValue bool
+
+	// isActiveErr indicates whether 'systemctl is-active ...' returns an error or not.
+	isActiveErr bool
+
+	// statusOpts are options to set for the behavior of 'nmcli dev status'
+	statusOpts nmStatusOpts
+}
+
+func (n nmMockRunner) Quiet(ctx context.Context, name string, args ...string) error {
+	return nil
+}
+
+func (n nmMockRunner) WithOutput(ctx context.Context, name string, args ...string) *run.Result {
+	if name == "systemctl" {
+		if slices.Contains(args, "status") && slices.Contains(args, "network.service") {
+			if n.networkServiceValue {
+				return &run.Result{
+					StdOut: "NetworkManager.service",
+				}
+			}
+			return &run.Result{}
+		}
+		if slices.Contains(args, "is-active") && slices.Contains(args, "NetworkManager.service") {
+			if n.isActiveErr {
+				return &run.Result{
+					ExitCode: 1,
+				}
+			}
+			return &run.Result{}
+		}
+	}
+	if name == "nmcli" && slices.Contains(args, "dev") && slices.Contains(args, "status") {
+		if n.statusOpts.returnError {
+			return &run.Result{
+				ExitCode: 1,
+				StdErr:   "mock error status",
+			}
+		}
+		if n.statusOpts.managed {
+			return &run.Result{
+				StdOut: "iface:connected\nlo:unmanaged",
+			}
+		}
+		return &run.Result{
+			StdOut: "iface:unmanaged\nlo:connected(externally)",
+		}
+	}
+	return &run.Result{}
+}
+
+func (n nmMockRunner) WithOutputTimeout(ctx context.Context, timeout time.Duration, name string, args ...string) *run.Result {
+	return &run.Result{}
+}
+
+func (n nmMockRunner) WithCombinedOutput(ctx context.Context, name string, args ...string) *run.Result {
+	return &run.Result{}
+}
+
+// nmTestOpts are options to set for test environment setup.
+type nmTestOpts struct {
+	// lookPathOpts contains options to set for the behavior of exec.LookPath.
+	lookPathOpts nmLookPathOpts
+
+	// runnerOpts contains options to set for the network manager mock runner.
+	runnerOpts nmRunnerOpts
+}
+
+// nmLookPathOpts are options to set for the behavior of exec.LookPath.
+type nmLookPathOpts struct {
+	// returnValue determines the return value of exec.LookPath.
+	returnValue bool
+
+	// returnError determines whether exec.LookPath should return an error.
+	// This takes precedence over returnValue.
+	returnError bool
+}
+
+// nmRunnerOpts are options to set for the network manager test's mock runner.
+type nmRunnerOpts struct {
+	// networkServiceValue is the return value of 'systemctl status network.service'.
+	networkServiceValue bool
+
+	// isActiveErr indicates whether 'systemctl is-active ...' returns an error or not.
+	isActiveErr bool
+
+	// statusOpts are options to set for the behavior of 'nmcli dev status'
+	statusOpts nmStatusOpts
+}
+
+// nmStatusOpts are options to set for the behavior of 'nmcli dev status'.
+type nmStatusOpts struct {
+	// managed indicates whether the interface is managed.
+	managed bool
+
+	// returnError indicates whether 'nmcli dev status' should return an error.
+	returnError bool
+}
+
+// nmTestSetup sets up the environment before each test.
+func nmTestSetup(t *testing.T, opts nmTestOpts) {
+	t.Helper()
+
+	lookPathOpts := opts.lookPathOpts
+	if lookPathOpts.returnError {
+		execLookPath = func(name string) (string, error) {
+			return "", fmt.Errorf("mock error lookpath")
+		}
+	} else if lookPathOpts.returnValue {
+		execLookPath = func(name string) (string, error) {
+			return name, nil
+		}
+	} else {
+		execLookPath = func(name string) (string, error) {
+			return name, exec.ErrNotFound
+		}
+	}
+
+	runnerOpts := opts.runnerOpts
+	run.Client = &nmMockRunner{
+		networkServiceValue: runnerOpts.networkServiceValue,
+		isActiveErr:         runnerOpts.isActiveErr,
+		statusOpts:          runnerOpts.statusOpts,
+	}
+}
+
+// nmTestTearDown cleans up the test environment after each test.
+func nmTestTearDown(t *testing.T) {
+	t.Helper()
+
+	run.Client = &run.Runner{}
+	testNetworkManager.configDir = defaultNetworkManagerConfigDir
+}
+
+// TestNetworkManagerIsManaging tests whether networkManager's IsManaging returns the
+// correct values provided various mock environment setups.
+func TestNetworkManagerIsManaging(t *testing.T) {
+	tests := []struct {
+		// name is the name of this test.
+		name string
+
+		// opts are options to set for the mock runner.
+		opts nmTestOpts
+
+		// expectedRes is the expected return value of IsManaging().
+		expectedRes bool
+
+		// expectErr indicates whether to expect an error.
+		expectErr bool
+
+		// expectedErr is the expected error message if an error is expected.
+		expectedErr string
+	}{
+		// lookpath nmcli does not exist.
+		{
+			name:        "lookpath-nmcli-not-exist",
+			opts:        nmTestOpts{},
+			expectedRes: false,
+			expectErr:   false,
+		},
+		// lookpath nmcli error.
+		{
+			name: "lookpath-nmcli-error",
+			opts: nmTestOpts{
+				lookPathOpts: nmLookPathOpts{
+					returnError: true,
+				},
+			},
+			expectedRes: false,
+			expectErr:   true,
+			expectedErr: "error checking for nmcli: mock error lookpath",
+		},
+		// 'systemctl is-active NetworkManager.service' error.
+		{
+			name: "is-active-error",
+			opts: nmTestOpts{
+				lookPathOpts: nmLookPathOpts{
+					returnValue: true,
+				},
+				runnerOpts: nmRunnerOpts{
+					isActiveErr: true,
+				},
+			},
+			expectedRes: false,
+			expectErr:   false,
+		},
+		// 'nmcli dev status' error.
+		{
+			name: "nmcli-error",
+			opts: nmTestOpts{
+				lookPathOpts: nmLookPathOpts{
+					returnValue: true,
+				},
+				runnerOpts: nmRunnerOpts{
+					statusOpts: nmStatusOpts{
+						returnError: true,
+					},
+				},
+			},
+			expectedRes: false,
+			expectErr:   true,
+			expectedErr: "error checking status of devices on NetworkManager: mock error status",
+		},
+		// 'nmcli dev status' unmanaged.
+		{
+			name: "nmcli-unmanaged",
+			opts: nmTestOpts{
+				lookPathOpts: nmLookPathOpts{
+					returnValue: true,
+				},
+				runnerOpts: nmRunnerOpts{
+					statusOpts: nmStatusOpts{
+						managed: false,
+					},
+				},
+			},
+			expectedRes: false,
+			expectErr:   false,
+		},
+		// 'nmcli dev status' managed.
+		{
+			name: "nmcli-managed",
+			opts: nmTestOpts{
+				lookPathOpts: nmLookPathOpts{
+					returnValue: true,
+				},
+				runnerOpts: nmRunnerOpts{
+					statusOpts: nmStatusOpts{
+						managed: true,
+					},
+				},
+			},
+			expectedRes: true,
+			expectErr:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			nmTestSetup(t, test.opts)
+
+			res, err := testNetworkManager.IsManaging(ctx, "iface")
+			if test.expectErr {
+				if err == nil {
+					t.Fatalf("no error returned when error expected")
+				}
+				if err.Error() != test.expectedErr {
+					t.Fatalf("unexpected error message.\nExpected: %s\nActual: %v\n", test.expectedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res != test.expectedRes {
+				t.Fatalf("unexpected response. Expected: %v, Actual: %v", test.expectedRes, res)
+			}
+
+			nmTestTearDown(t)
+		})
+	}
+}
+
+// TestWriteNetworkManagerConfigs tests whether writeNetworkManagerConfigs() correclty writes
+// the connection files to the correct place and contain the correct contents.
+func TestWriteNetworkManagerConfigs(t *testing.T) {
+	tests := []struct {
+		// name is the name of this test.
+		name string
+
+		// testInterfaces is the list of test interfaces.
+		testInterfaces []string
+
+		// expectedIDs is the list of expected IDs.
+		expectedIDs []string
+
+		// expectedFiles is the list of expected files.
+		expectedFiles []string
+	}{
+		// One interface.
+		{
+			name:           "one-nic",
+			testInterfaces: []string{"iface"},
+			expectedIDs:    []string{"google-guest-agent-iface"},
+			expectedFiles: []string{
+				"google-guest-agent-iface.nmconnection",
+			},
+		},
+		// Multiple interfaces.
+		{
+			name:           "multinic",
+			testInterfaces: []string{"iface0", "iface1", "iface2"},
+			expectedIDs: []string{
+				"google-guest-agent-iface0",
+				"google-guest-agent-iface1",
+				"google-guest-agent-iface2",
+			},
+			expectedFiles: []string{
+				"google-guest-agent-iface0.nmconnection",
+				"google-guest-agent-iface1.nmconnection",
+				"google-guest-agent-iface2.nmconnection",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nmTestSetup(t, nmTestOpts{})
+
+			configDir := path.Join(t.TempDir(), "system-connections")
+			if err := os.MkdirAll(configDir, 0755); err != nil {
+				t.Fatalf("error creating temp dir: %v", err)
+			}
+			testNetworkManager.configDir = configDir
+
+			conns, err := testNetworkManager.writeNetworkManagerConfigs(test.testInterfaces)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for i, conn := range conns {
+				if conn != test.expectedIDs[i] {
+					t.Fatalf("unexpected connection ID. Expected: %s, Actual: %s", test.expectedIDs[i], conn)
+				}
+
+				// Load the file and check the sections.
+				configFilePath := path.Join(configDir, test.expectedFiles[i])
+				opts := ini.LoadOptions{
+					Loose:       true,
+					Insensitive: true,
+				}
+
+				configFile, err := ini.LoadSources(opts, configFilePath)
+				if err != nil {
+					t.Fatalf("error reading config: %v", err)
+				}
+
+				config := new(nmConfig)
+				if err = configFile.MapTo(config); err != nil {
+					t.Fatalf("error parsing config ini: %v", err)
+				}
+
+				if !config.GuestAgent.Managed {
+					t.Fatalf("guest-agent's managed key is set to false, expected true")
+				}
+
+				if config.Connection.ID != test.expectedIDs[i] {
+					t.Fatalf("unexpected connection id. Expected: %v, Actual: %v", test.expectedIDs[i], config.Connection.ID)
+				}
+
+				if config.Connection.InterfaceName != test.testInterfaces[i] {
+					t.Fatalf("unexpected interface name. Expected: %v, Actual: %v", test.testInterfaces[i], config.Connection.InterfaceName)
+				}
+			}
+
+			nmTestTearDown(t)
+		})
+	}
+}

--- a/google_guest_agent/network/manager/systemd_networkd_linux.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux.go
@@ -62,13 +62,6 @@ func init() {
 	}, false)
 }
 
-// guestAgent contains the guest-agent control flags/data.
-type guestAgent struct {
-	// ManagedByGuestAgent determines if a given configuration was written and is
-	// managed by guest-agent.
-	ManagedByGuestAgent bool
-}
-
 // systemdMatchConfig contains the systemd-networkd's interface matching criteria.
 type systemdMatchConfig struct {
 	// Name is the matching criteria based on the interface name.
@@ -101,7 +94,7 @@ type systemdDHCPConfig struct {
 // Ultimately the structure will be unmarshalled into a .ini file.
 type systemdConfig struct {
 	// GuestAgent is a section containing guest-agent control flags/data.
-	GuestAgent guestAgent
+	GuestAgent guestAgentSection
 
 	// Match is the systemd-networkd ini file's [Match] section.
 	Match systemdMatchConfig
@@ -207,8 +200,8 @@ func writeSystemdConfig(interfaces, ipv6Interfaces []string, configDir, priority
 
 		// Create and setup ini file.
 		data := systemdConfig{
-			GuestAgent: guestAgent{
-				ManagedByGuestAgent: true,
+			GuestAgent: guestAgentSection{
+				Managed: true,
 			},
 			Match: systemdMatchConfig{
 				Name: iface,
@@ -280,7 +273,7 @@ func (n systemdNetworkd) Rollback(ctx context.Context, payload []metadata.Networ
 		}
 
 		// Check that the guest section exists and the key is set to true.
-		if sections.GuestAgent.ManagedByGuestAgent {
+		if sections.GuestAgent.Managed {
 			logger.Debugf("removing %s", configFile)
 			if err = os.Remove(configFile); err != nil && !os.IsNotExist(err) {
 				return err

--- a/google_guest_agent/network/manager/systemd_networkd_linux_test.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux_test.go
@@ -517,7 +517,7 @@ func TestSystemdNetworkdConfig(t *testing.T) {
 				}
 
 				// Check for the GuestAgent section.
-				if !sections.GuestAgent.ManagedByGuestAgent {
+				if !sections.GuestAgent.Managed {
 					t.Errorf("%s missing guest agent section", file.Name())
 				}
 


### PR DESCRIPTION
- Deleted the `nativeOSConfig` field in the `osRules` as that will no longer be needed.
- Deleted the `broadVersion` and related variables, as they will no longer be used after this and the Wicked implementation.
- Created NetworkManager tests.

The current behavior is as follows:
1. Guest Agent writes its own `.nmconnections` file for each interface under `/etc/NetworkManager/system-connections`.
2. We then load those connection files into `nmcli`, then enable those new connections
  i. This overrides the default system connections, which are called `Wired Connection 1`, `Wired Connection 2`, etc...
3. Upon rebooting the system, we lose the default system connections. This is more or less intended because those connections reside in the `/run` directory, which gets cleared upon reboot.