### PR TITLE
Skip interface manager on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace github.com/GoogleCloudPlatform/guest-agent/metadata => ../metadata
 require (
 	cloud.google.com/go/storage v1.31.0
 	github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20230710215706-450679fd88a9
+	github.com/Microsoft/go-winio v0.6.1
 	github.com/go-ini/ini v1.66.6
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/protobuf v1.5.3
@@ -19,6 +20,7 @@ require (
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
 	golang.org/x/crypto v0.11.0
 	golang.org/x/sys v0.11.0
+	google.golang.org/api v0.134.0
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
 	software.sslmate.com/src/go-pkcs12 v0.2.1
@@ -31,7 +33,6 @@ require (
 	cloud.google.com/go/iam v1.1.1 // indirect
 	cloud.google.com/go/logging v1.7.0 // indirect
 	cloud.google.com/go/longrunning v0.5.1 // indirect
-	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/google/go-sev-guest v0.7.0 // indirect
 	github.com/google/logger v1.1.1 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
@@ -48,7 +49,6 @@ require (
 	golang.org/x/text v0.11.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	google.golang.org/api v0.134.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230726155614-23370e0ffb3e // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,10 +96,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.5/go.mod h1:RxW0N9901Cko
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/kardianos/service v1.2.1 h1:AYndMsehS+ywIS6RB9KOlcXzteWUzxgMgBymJD7+BYk=
 github.com/kardianos/service v1.2.1/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -274,10 +274,13 @@ func (a *addressMgr) Set(ctx context.Context) error {
 		a.applyWSFCFilter(config)
 	}
 
-	// Setup network interfaces.
-	err := network.SetupInterfaces(ctx, config, newMetadata.Instance.NetworkInterfaces)
-	if err != nil {
-		return fmt.Errorf("failed to setup network interfaces: %v", err)
+	// Guest Agent does not manage interfaces on Windows.
+	if runtime.GOOS != "windows" {
+		// Setup network interfaces.
+		err := network.SetupInterfaces(ctx, config, newMetadata.Instance.NetworkInterfaces)
+		if err != nil {
+			return fmt.Errorf("failed to setup network interfaces: %v", err)
+		}
 	}
 
 	if !config.NetworkInterfaces.IPForwarding {


### PR DESCRIPTION
Address manager fails with error if ran on windows causing to skip all further steps - 

`
 [&main.addressMgr{}] Failed to run manager Set() call: failed to setup network interfaces: error detecting network manager service: no network manager impl found for Ethernet
`

/cc @drewhli @dorileo 