### PR TITLE
Add COS homedir-gid patch to upstream.

### DIFF
--- a/google_guest_agent/accounts_windows.go
+++ b/google_guest_agent/accounts_windows.go
@@ -138,7 +138,7 @@ func addUserToGroup(ctx context.Context, username, group string) error {
 	return nil
 }
 
-func createUser(ctx context.Context, username, pwd string) error {
+func createUser(ctx context.Context, username, pwd, _ string) error {
 	uPtr, err := syscall.UTF16PtrFromString(username)
 	if err != nil {
 		return fmt.Errorf("error encoding username to UTF16: %v", err)
@@ -184,6 +184,6 @@ func userExists(name string) (bool, error) {
 	return true, nil
 }
 
-func getUID(path string) string {
-	return ""
+func getUIDAndGID(path string) (string, string) {
+	return "", ""
 }

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -344,12 +344,12 @@ func createUserGroupCmd(cmd, user, group string) (string, []string) {
 // createGoogleUser creates a Google managed user account if needed and adds it
 // to the configured groups.
 func createGoogleUser(ctx context.Context, config *cfg.Sections, user string) error {
-	var uid string
+	var uid, gid string
 	if config.Accounts.ReuseHomedir {
-		uid = getUID(fmt.Sprintf("/home/%s", user))
+		uid, gid = getUIDAndGID(fmt.Sprintf("/home/%s", user))
 	}
 
-	if err := createUser(ctx, user, uid); err != nil {
+	if err := createUser(ctx, user, uid, gid); err != nil {
 		return err
 	}
 	groups := config.Accounts.Groups

--- a/google_guest_agent/windows_accounts.go
+++ b/google_guest_agent/windows_accounts.go
@@ -134,7 +134,7 @@ func createOrResetPwd(ctx context.Context, k metadata.WindowsKey) (*credsJSON, e
 		}
 	} else {
 		logger.Infof("Creating user %s", k.UserName)
-		if err := createUser(ctx, k.UserName, pwd); err != nil {
+		if err := createUser(ctx, k.UserName, pwd, ""); err != nil {
 			return nil, fmt.Errorf("error running createUser: %v", err)
 		}
 		if k.AddToAdministrators == nil || *k.AddToAdministrators {
@@ -156,7 +156,7 @@ func createSSHUser(ctx context.Context, user string) error {
 		return nil
 	}
 	logger.Infof("Creating user %s", user)
-	if err := createUser(ctx, user, pwd); err != nil {
+	if err := createUser(ctx, user, pwd, ""); err != nil {
 		return fmt.Errorf("error running createUser: %v", err)
 	}
 


### PR DESCRIPTION
This patch was made to fix a problem where you can become unable to create a user due to a UID/GID conflict. We've maintained the patch but it'd be better to upstream it so we don't have to worry about a regression while upgrading the guest agent in COS.