### PR TITLE
network: early setup network

### DIFF
--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -159,6 +159,9 @@ func agentInit(ctx context.Context) {
 			}
 		}
 
+		// Early setup the network configurations before we notify systemd we are done.
+		runManager(ctx, addressManager)
+
 		// Disable overcommit accounting; e2 instances only.
 		parts := strings.Split(newMetadata.Instance.MachineType, "/")
 		if strings.HasPrefix(parts[len(parts)-1], "e2-") {


### PR DESCRIPTION
Make sure we do our first network setup attempt before notifying the system's service manager and honor the dependencies after we know the network configuration is stable (not changing).