### PR TITLE
address manager: make sure we check for oldMetadata

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -231,6 +231,11 @@ func (a *addressMgr) applyWSFCFilter(config *cfg.Sections) {
 }
 
 func (a *addressMgr) Diff(ctx context.Context) (bool, error) {
+	// Return true if this is the first call (when the first mds descriptor is available).
+	if oldMetadata == nil {
+		return true, nil
+	}
+
 	config := cfg.Get()
 	wsfcAddresses := a.parseWSFCAddresses(config)
 	wsfcEnable := a.parseWSFCEnable(config)


### PR DESCRIPTION
Since now we are calling the address manager in the early setup we will not have the oldMetadata instance at that point, make sure we check that.