### PR TITLE
NetworkManager: only set secondary interfaces as up

### DIFF
--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -150,8 +150,8 @@ func (n networkManager) SetupEthernetInterface(ctx context.Context, config *cfg.
 		return fmt.Errorf("error reloading NetworkManager config cache: %v", err)
 	}
 
-	// Enable the new connections.
-	for _, ifname := range interfaces {
+	// Enable the new connections. Ignore the primary interface as it will already be up.
+	for _, ifname := range interfaces[1:] {
 		if err = run.Quiet(ctx, "nmcli", "conn", "up", "ifname", ifname); err != nil {
 			return fmt.Errorf("error enabling connection %s: %v", ifname, err)
 		}


### PR DESCRIPTION
The primary interface will already be up, by doing "conn up" we are forcing primary interface to be "reloaded" twice as we just reloaded the configuration with "conn reload" - by double "reloading" the primary interface we are forcing it to be unavailable longer than we need it to.