### PR TITLE
change metadata key to enable-oslogin-certificates

### DIFF
--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -676,7 +676,7 @@ func TestGetOSLoginEnabled(t *testing.T) {
 			reqCerts:  false,
 		},
 		{
-			md:        `{"project": {"attributes": {"enable-oslogin": "true", "enable-oslogin-2fa": "true", "require-oslogin-certificates": "true"}}}`,
+			md:        `{"project": {"attributes": {"enable-oslogin": "true", "enable-oslogin-2fa": "true", "enable-oslogin-certificates": "true"}}}`,
 			enable:    true,
 			twofactor: true,
 			skey:      false,
@@ -724,7 +724,7 @@ func TestGetOSLoginEnabled(t *testing.T) {
 		},
 		{
 			// ReqCerts test
-			md:        `{"instance": {"attributes": {"enable-oslogin": "true", "enable-oslogin-2fa": "true", "require-oslogin-certificates": "true"}}}`,
+			md:        `{"instance": {"attributes": {"enable-oslogin": "true", "enable-oslogin-2fa": "true", "enable-oslogin-certificates": "true"}}}`,
 			enable:    true,
 			twofactor: true,
 			skey:      false,

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -240,7 +240,7 @@ func (a *Attributes) UnmarshalJSON(b []byte) error {
 		SSHKeys               string      `json:"ssh-keys"`
 		TwoFactor             string      `json:"enable-oslogin-2fa"`
 		SecurityKey           string      `json:"enable-oslogin-sk"`
-		RequireCerts          string      `json:"require-oslogin-certificates"`
+		RequireCerts          string      `json:"enable-oslogin-certificates"`
 		WindowsKeys           WindowsKeys `json:"windows-keys"`
 		WSFCAddresses         string      `json:"wsfc-addrs"`
 		WSFCAgentPort         string      `json:"wsfc-agent-port"`


### PR DESCRIPTION
After discussion among the OS Login team, we will be using "enable-oslogin-certificates" as the metadata key instead of "require-oslogin-certificates". This is to match the existing OS Login metadata format.