### PR TITLE
oslogin: don't remove sshca watcher when oslogin is disabled

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -99,14 +99,6 @@ func enableDisableOSLoginCertAuth(ctx context.Context) error {
 			}
 			sshca.Init()
 		}
-	} else {
-		if trustedCAWatcher != nil {
-			if err := eventManager.RemoveWatcher(ctx, trustedCAWatcher); err != nil {
-				return err
-			}
-			sshca.Close()
-			trustedCAWatcher = nil
-		}
 	}
 
 	return nil


### PR DESCRIPTION
It's is innocuous to have the watcher or not enabled, we better avoid having to re-register the watcher between enable and disable cycles.