### PR TITLE
Enabling logging in google-startup-script.service

### DIFF
--- a/google-startup-scripts.service
+++ b/google-startup-scripts.service
@@ -9,6 +9,8 @@ Type=oneshot
 ExecStart=/usr/bin/google_metadata_script_runner startup
 #TimeoutStartSec is ignored for Type=oneshot service units.
 KillMode=process
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Enable logging in google-startup-script.service.

This will allow us to exit CIT successfully.

CCing @a-crate, @dorileo, @zmarano.