### PR TITLE
Disable OS Login without pruning off any extra suffix.

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -356,7 +356,7 @@ func updateNSSwitchConfig(nsswitch string, enable bool) string {
 			if enable && !present {
 				line += oslogin
 			} else if !enable && present {
-				line = strings.TrimSuffix(line, oslogin)
+				line = strings.Replace(line, oslogin, "", 1)
 			}
 
 			if runtime.GOOS == "freebsd" {

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -173,6 +173,19 @@ func TestUpdateNSSwitchConfig(t *testing.T) {
 			},
 			enable: true,
 		},
+		{
+			contents: []string{
+				"line1",
+				"passwd: line2" + oslogin + " some_other_service",
+				"group: line3" + oslogin + " another_service",
+			},
+			want: []string{
+				"line1",
+				"passwd: line2 some_other_service",
+				"group: line3 another_service",
+			},
+			enable: false,
+		},
 	}
 
 	for idx, tt := range tests {


### PR DESCRIPTION
This small change fixes an issue where, if a user had added more NSS plugins to their `/etc/nsswitch.conf` file, disabling OS Login would cause those extra plugins to be silently dropped from the NSS config. 

Although we don't strictly support using OS Login with other NSS plugins, we should make sure that our installation script isn't so brittle that it quietly breaks other NSS plugins.