### PR TITLE
Update NIC management strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ MetadataScripts   | startup                | `false` disables startup script exe
 MetadataScripts   | shutdown               | `false` disables shutdown script execution.
 NetworkInterfaces | setup                  | `false` skips network interface setup.
 NetworkInterfaces | ip\_forwarding         | `false` skips IP forwarding.
+NetworkInterfaces | manage\_primary\_nic   | `true` will start managing the primary NIC in addition to the secondary NICs.
 NetworkInterfaces | dhcp\_command          | String path for alternate dhcp executable used to enable network interfaces.
 OSLogin           | cert_authentication    | `false` prevents guest-agent from setting up sshd's `TrustedUserCAKeys`, `AuthorizedPrincipalsCommand` and `AuthorizedPrincipalsCommandUser` configuration keys. Default value: `true`.
 

--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -87,6 +87,7 @@ sysprep-specialize = true
 dhcp_command =
 ip_forwarding = true
 setup = true
+manage_primary_nic =
 
 [OSLogin]
 cert_authentication = true
@@ -260,9 +261,10 @@ type MDS struct {
 
 // NetworkInterfaces contains the configurations of NetworkInterfaces section.
 type NetworkInterfaces struct {
-	DHCPCommand  string `ini:"dhcp_command,omitempty"`
-	IPForwarding bool   `ini:"ip_forwarding,omitempty"`
-	Setup        bool   `ini:"setup,omitempty"`
+	DHCPCommand      string `ini:"dhcp_command,omitempty"`
+	IPForwarding     bool   `ini:"ip_forwarding,omitempty"`
+	Setup            bool   `ini:"setup,omitempty"`
+	ManagePrimaryNIC bool   `ini:"manage_primary_nic,omitempty"`
 }
 
 // Snapshots contains the configurations of Snapshots section.

--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -425,7 +425,12 @@ func partitionInterfaces(ctx context.Context, interfaces, ipv6Interfaces []strin
 	var obtainIpv6Interfaces []string
 	var releaseIpv6Interfaces []string
 
-	for _, iface := range interfaces {
+	for i, iface := range interfaces {
+		if !shouldManageInterface(i == 0) {
+			// Do not setup anything for this interface to avoid duplicate processes.
+			continue
+		}
+
 		// Check for IPv4 interfaces for which to obtain a lease.
 		processExists, err := dhclientProcessExists(ctx, iface, ipv4)
 		if err != nil {

--- a/google_guest_agent/network/manager/dhclient_linux_test.go
+++ b/google_guest_agent/network/manager/dhclient_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/osinfo"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/ps"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
@@ -135,6 +136,9 @@ type dhclientProcessOpts struct {
 // dhclientTestSetup sets up the test.
 func dhclientTestSetup(t *testing.T, opts dhclientTestOpts) {
 	t.Helper()
+	if err := cfg.Load(nil); err != nil {
+		t.Fatalf("cfg.Load(nil) = %v, nil", err)
+	}
 
 	// We have to mock dhclientProcessExists as we cannot mock where the ps
 	// package checks for processes here.
@@ -276,42 +280,42 @@ func TestPartitionInterfaces(t *testing.T) {
 	}{
 		{
 			name:                "all-ipv4",
-			testInterfaces:      []string{"obtain1", "obtain2"},
+			testInterfaces:      []string{"primary1", "obtain2"},
 			testIpv6Interfaces:  []string{},
 			existFlags:          []bool{false, false},
 			ipVersions:          []ipVersion{ipv4, ipv4},
-			expectedObtainIpv4:  []string{"obtain1", "obtain2"},
+			expectedObtainIpv4:  []string{"obtain2"},
 			expectedObtainIpv6:  []string{},
 			expectedReleaseIpv6: []string{},
 		},
 		{
 			name:                "all-ipv6",
-			testInterfaces:      []string{"obtain1", "obtain2"},
-			testIpv6Interfaces:  []string{"obtain1", "obtain2"},
+			testInterfaces:      []string{"primary1", "obtain2"},
+			testIpv6Interfaces:  []string{"primary1", "obtain2"},
 			existFlags:          []bool{false, false},
 			ipVersions:          []ipVersion{ipv6, ipv6},
-			expectedObtainIpv4:  []string{"obtain1", "obtain2"},
-			expectedObtainIpv6:  []string{"obtain1", "obtain2"},
+			expectedObtainIpv4:  []string{"obtain2"},
+			expectedObtainIpv6:  []string{"obtain2"},
 			expectedReleaseIpv6: []string{},
 		},
 		{
 			name:                "ipv4-ipv6",
-			testInterfaces:      []string{"obtain1", "obtain2"},
+			testInterfaces:      []string{"primary1", "obtain2"},
 			testIpv6Interfaces:  []string{"obtain2"},
 			existFlags:          []bool{false, false},
 			ipVersions:          []ipVersion{ipv4, ipv6},
-			expectedObtainIpv4:  []string{"obtain1", "obtain2"},
+			expectedObtainIpv4:  []string{"obtain2"},
 			expectedObtainIpv6:  []string{"obtain2"},
 			expectedReleaseIpv6: []string{},
 		},
 		{
 			name:                "release-ipv6",
-			testInterfaces:      []string{"obtain1", "release1"},
-			testIpv6Interfaces:  []string{"obtain1"},
+			testInterfaces:      []string{"primary1", "release1"},
+			testIpv6Interfaces:  []string{"primary1"},
 			existFlags:          []bool{false, true},
 			ipVersions:          []ipVersion{ipv4, ipv6},
-			expectedObtainIpv4:  []string{"obtain1", "release1"},
-			expectedObtainIpv6:  []string{"obtain1"},
+			expectedObtainIpv4:  []string{"release1"},
+			expectedObtainIpv6:  []string{},
 			expectedReleaseIpv6: []string{"release1"},
 		},
 	}

--- a/google_guest_agent/network/manager/manager_linux.go
+++ b/google_guest_agent/network/manager/manager_linux.go
@@ -18,7 +18,7 @@ func init() {
 	// knownNetworkManagers is a list of supported/available network managers.
 	knownNetworkManagers = []Service{
 		&netplan{
-			netplanConfigDir:  "/etc/netplan/",
+			netplanConfigDir:  "/run/netplan/",
 			networkdDropinDir: "/etc/systemd/network/",
 			priority:          20,
 		},

--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -256,5 +256,8 @@ func (n networkManager) Rollback(ctx context.Context, nics *Interfaces) error {
 		}
 	}
 
+	if err := run.Quiet(ctx, "nmcli", "conn", "reload"); err != nil {
+		return fmt.Errorf("error reloading NetworkManager config cache: %v", err)
+	}
 	return nil
 }

--- a/google_guest_agent/network/manager/wicked_linux.go
+++ b/google_guest_agent/network/manager/wicked_linux.go
@@ -55,7 +55,7 @@ func (n wicked) Name() string {
 
 // Configure gives the opportunity for the Service implementation to adjust its configuration
 // based on the Guest Agent configuration.
-func (n wicked) Configure(ctx context.Context, config *cfg.Sections) {
+func (n *wicked) Configure(ctx context.Context, config *cfg.Sections) {
 	wickedCommand, err := exec.LookPath("wicked")
 	if err != nil {
 		logger.Infof("failed to find wicked path, falling back to default: %+v", err)


### PR DESCRIPTION
See commit messages for details. Short version: bring back OS rules with a configuration option to ignore them. 
Stop removing the default configuration on Debian 12, write a config with a higher priority.
Add a network recovery strategy, executed when then MDS is inaccessible on startup. Remove all guest agent configuration and go back to the OS default, exit with a failure if the MDS is still inaccessible with the default configuration.

/hold
/cc @ChaitanyaKulkarni28 @drewhli 