### PR TITLE
Add ipv6 support to forward ips in guest agent

### DIFF
--- a/google_guest_agent/addresses_test.go
+++ b/google_guest_agent/addresses_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"testing"
 
@@ -211,6 +212,33 @@ func TestWsfcFlagTriggerAddressDiff(t *testing.T) {
 
 			if !diff {
 				t.Errorf("old: %v new: %v doesn't trigger diff.", tt.oldMetadata, tt.newMetadata)
+			}
+		})
+	}
+}
+
+func TestIsIPv6(t *testing.T) {
+	tests := []struct {
+		ip   net.IP
+		want bool
+		name string
+	}{
+		{
+			name: "valid_ipv4",
+			ip:   net.ParseIP("1.2.3.4"),
+			want: false,
+		},
+		{
+			name: "valid_ipv6",
+			ip:   net.ParseIP("fd20:b8f:5d95:2000:0:2::"),
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isIPv6(test.ip); got != test.want {
+				t.Errorf("isIPv6(%s) = %t, want %t", test.ip.String(), got, test.want)
 			}
 		})
 	}

--- a/google_guest_agent/addresses_unix.go
+++ b/google_guest_agent/addresses_unix.go
@@ -23,7 +23,7 @@ import (
 )
 
 // TODO: addLocalRoute and addRoute should be merged with the addition of ipForwardType to ipForwardEntry.
-func addIPForwardEntry(route ipForwardEntry) error {
+func addIPForwardEntry(ipForwardEntry) error {
 	return errors.New("addIPForwardEntry unimplemented on non Windows systems")
 }
 
@@ -32,10 +32,10 @@ func getIPForwardEntries() ([]ipForwardEntry, error) {
 	return nil, errors.New("getIPForwardEntries unimplemented on non Windows systems")
 }
 
-func addAddress(ip net.IP, mask net.IPMask, index uint32) error {
+func addAddress(net.IP, net.IPMask, uint32) error {
 	return errors.New("addAddress unimplemented on non Windows systems")
 }
 
-func removeAddress(ip net.IP, index uint32) error {
+func removeAddress(net.IP, net.IPMask, uint32) error {
 	return errors.New("removeAddress unimplemented on non Windows systems")
 }


### PR DESCRIPTION
Guest Agent on windows assumes forward ips to always be ipv4 addresses and runs into restart loop if it receives ipv6 address. This changes retains the existing behavior for ipv4 addresses and adds support for adding/removing ipv6 unicast addresses.

/cc @a-crate @drewhli 