### PR TITLE
Only release dhclient leases for an interface if the respective dhclient is still running

### DIFF
--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -494,7 +494,7 @@ func (n dhclient) Rollback(ctx context.Context, nics *Interfaces) error {
 
 	// Release all the interface leases from dhclient.
 	for _, iface := range googleInterfaces {
-		ipv4Exists, err := dhclientProcessExists(ctx, iface, ipv4);
+		ipv4Exists, err := dhclientProcessExists(ctx, iface, ipv4)
 		if err != nil {
 			return fmt.Errorf("error checking if ipv4 dhclient process for %s exists: %v", iface, err)
 		}
@@ -505,7 +505,7 @@ func (n dhclient) Rollback(ctx context.Context, nics *Interfaces) error {
 		}
 	}
 	for _, iface := range googleIpv6Interfaces {
-		ipv6Exists, err := dhclientProcessExists(ctx, iface, ipv6);
+		ipv6Exists, err := dhclientProcessExists(ctx, iface, ipv6)
 		if err != nil {
 			return fmt.Errorf("error checking if ipv6 dhclient process for %s exists: %v", iface, err)
 		}

--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -494,13 +494,25 @@ func (n dhclient) Rollback(ctx context.Context, nics *Interfaces) error {
 
 	// Release all the interface leases from dhclient.
 	for _, iface := range googleInterfaces {
-		if err := runDhclient(ctx, ipv4, iface, true); err != nil {
-			return err
+		ipv4Exists, err := dhclientProcessExists(ctx, iface, ipv4);
+		if err != nil {
+			return fmt.Errorf("error checking if ipv4 dhclient process for %s exists: %v", iface, err)
+		}
+		if ipv4Exists {
+			if err = runDhclient(ctx, ipv4, iface, true); err != nil {
+				return err
+			}
 		}
 	}
 	for _, iface := range googleIpv6Interfaces {
-		if err := runDhclient(ctx, ipv6, iface, true); err != nil {
-			return err
+		ipv6Exists, err := dhclientProcessExists(ctx, iface, ipv6);
+		if err != nil {
+			return fmt.Errorf("error checking if ipv6 dhclient process for %s exists: %v", iface, err)
+		}
+		if ipv6Exists {
+			if err = runDhclient(ctx, ipv6, iface, true); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This resolves an issue on IPv6-only instances on SUSE systems, where the `guest-agent` attempts to release `dhcp4` leases, where it then hangs and causes the `guest-agent` startup process to timeout, leading to on-off network connection as well as an agent restart loop.

From this, we also found an issue with `cloud-netconfig` on SUSE systems. There seems to be some sort of conflict between the `guest-agent` configurations and `cloud-netconfig` configurations, causing `cloud-netconfig` to go on a restart loop. This will be investigated and addressed in a follow-up PR.