### PR TITLE
Fix where agent panics on nil event in sshca watcher

### DIFF
--- a/google_guest_agent/sshca/sshca.go
+++ b/google_guest_agent/sshca/sshca.go
@@ -63,7 +63,12 @@ func writeFile(ctx context.Context, evType string, data interface{}, evData *eve
 	}
 
 	// Make sure we close the pipe after we've done writing to it.
-	pipeData := evData.Data.(*sshtrustedca.PipeData)
+	pipeData, ok := evData.Data.(*sshtrustedca.PipeData)
+	if !ok {
+		logger.Errorf("Received invalid event data (%+v), ignoring this event and un-subscribing %s", evData.Data, evType)
+		return false
+	}
+
 	defer func() {
 		if err := pipeData.File.Close(); err != nil {
 			logger.Errorf("Failed to close pipe: %+v", err)


### PR DESCRIPTION
Fixes the edge case where agent panics during stop - 

```
 systemd[1]: Stopping google-guest-agent.service...
 google_guest_agent[682]: panic: interface conversion: interface {} is nil, not *sshtrustedca.PipeData
 google_guest_agent[682]: goroutine 69 [running]:
 google_guest_agent[682]: github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/sshca.writeFile({0xce1028?, 0xc000091f90?}, {0xc0001c0f40?, 0x20?}, {0x0?, 0x1?}, 0xc0002fa720?)
 google_guest_agent[682]:         google-guest-agent-20240314.00-r1/work/guest-agent-20240314.00/google_guest_agent/sshca/sshca.go:66 +0x45c
 google_guest_agent[682]: github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events.(*Manager).Run.func2(0xc000092960, 0xc0000929c0)
 google_guest_agent[682]:         /google-guest-agent-20240314.00-r1/work/guest-agent-20240314.00/google_guest_agent/events/events.go:425 +0x38c
 google_guest_agent[682]: created by github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/events.(*Manager).Run in goroutine 19
 google_guest_agent[682]:         /google-guest-agent-20240314.00-r1/work/guest-agent-20240314.00/google_guest_agent/events/events.go:408 +0x2fb
 systemd[1]: google-guest-agent.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
 systemd[1]: google-guest-agent.service: Failed with result 'exit-code'.
 systemd[1]: Stopped google-guest-agent.service.
```

/cc @dorileo @drewhli @a-crate 