### PR TITLE
Avoid writing configuration files when they already exist on wicked and NetworkManager

### DIFF
--- a/google_guest_agent/network/manager/netplan_linux.go
+++ b/google_guest_agent/network/manager/netplan_linux.go
@@ -154,7 +154,7 @@ func (n netplan) IsManaging(ctx context.Context, iface string) (bool, error) {
 		if errors.Is(err, exec.ErrNotFound) {
 			return false, nil
 		}
-		return false, fmt.Errorf("error looking up dhclient path: %v", err)
+		return false, fmt.Errorf("error looking up netplan path: %v", err)
 	}
 	return true, nil
 }
@@ -186,7 +186,7 @@ func (n netplan) SetupEthernetInterface(ctx context.Context, config *cfg.Section
 		return fmt.Errorf("error reloading systemd-networkd network configs: %v", err)
 	}
 
-	// Avoid restarting systemd-networkd.
+	// Avoid restarting netplan.
 	if err := run.Quiet(ctx, "netplan", "apply"); err != nil {
 		return fmt.Errorf("error applying netplan changes: %w", err)
 	}


### PR DESCRIPTION
The `wicked` change is an upstream from an [existing patch](https://build.opensuse.org/projects/openSUSE:Factory/packages/google-guest-agent/files/dont_overwrite_ifcfg.patch?expand=1 ). We also do the same for `NetworkManager` since they use the same `ifcfg` files, and no priority system exists for those. In this case, we only delete the old configuration files if they are managed by the guest agent. These are files written by the previous implementation of the network stack that simply disabled `NetworkManager`.

Included in this also are some small comment nits for `netplan`.

/cc @dorileo @a-crate @ChaitanyaKulkarni28 