### PR TITLE
Introduce a configuration toggle for enabling/disabling cloud logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Accounts          | usermod\_cmd           | Command string to modify a user's g
 Accounts          | gpasswd\_add\_cmd      | Command string to add a user to a group.
 Accounts          | gpasswd\_remove\_cmd   | Command string to remove a user from a group.
 Accounts          | groupadd\_cmd          | Command string to create a new group.
+Core              | cloud\_logging\_enabled| `false` disable cloud logging.
 Daemons           | accounts\_daemon       | `false` disables the accounts daemon.
 Daemons           | clock\_skew\_daemon    | `false` disables the clock skew daemon.
 Daemons           | network\_daemon        | `false` disables the network daemon.

--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -41,6 +41,9 @@ const (
 	unixConfigPath = `/etc/default/instance_configs.cfg`
 
 	defaultConfig = `
+[Core]
+cloud_logging_enabled = true
+
 [Accounts]
 deprovision_remove = false
 gpasswd_add_cmd = gpasswd -a {user} {group}
@@ -111,8 +114,18 @@ systemd_config_dir = /usr/lib/systemd/network
 `
 )
 
+// Core contains the core configuration entries of guest agent, all
+// configurations not tied/specific to a subsystem are defined in here.
+type Core struct {
+	// CloudLoggingEnabled config toggle controls Guest Agent cloud logger.
+	// Disabling it will stop Guest Agent for configuring and logging to Cloud Logging.
+	CloudLoggingEnabled bool `ini:"cloud_logging_enabled,omitempty"`
+}
+
 // Sections encapsulates all the configuration sections.
 type Sections struct {
+	// Core defines the core guest-agent's configuration entries/keys.
+	Core *Core `ini:"Core,omitempty"`
 	// AccountManager defines the address management configurations. It takes precedence over instance's
 	// and project's metadata configuration. The default configuration doesn't define values to it, if the
 	// user has defined it then we shouldn't even consider metadata values. Users must check if this

--- a/google_guest_agent/main.go
+++ b/google_guest_agent/main.go
@@ -154,6 +154,11 @@ func runUpdate(ctx context.Context) {
 
 func runAgent(ctx context.Context) {
 	opts := logger.LogOpts{LoggerName: programName}
+
+	if !cfg.Get().Core.CloudLoggingEnabled {
+		opts.DisableCloudLogging = true
+	}
+
 	if runtime.GOOS == "windows" {
 		opts.FormatFunction = logFormatWindows
 		opts.Writers = []io.Writer{&utils.SerialPort{Port: "COM1"}}


### PR DESCRIPTION
Guest Agent had by default cloud logging enabled with no way to disable it. As long as permissions are set agent would log into cloud logging. 

Users might want to disable any external access including google apis, allow disabling it without having to play with permissions, disabling the logging api or introduce firewall rules.