### PR TITLE
Add a configuration option to disable CA certificate updates

### DIFF
--- a/google_guest_agent/agentcrypto/mtls_mds_linux.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_linux.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
 	"github.com/GoogleCloudPlatform/guest-agent/utils"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
@@ -57,6 +58,11 @@ func (j *CredsJob) writeRootCACert(ctx context.Context, content []byte, outputFi
 	}
 	if err := utils.SaferWriteFile(content, outputFile, 0644); err != nil {
 		return err
+	}
+
+	if !cfg.Get().MDS.UpdateCACertificatesEnabled {
+		logger.Debugf("Skipping system store update as it is disabled in the configuration")
+		return nil
 	}
 
 	// Best effort to update system store, don't fail.

--- a/google_guest_agent/agentcrypto/mtls_mds_windows.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_windows.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	"github.com/GoogleCloudPlatform/guest-agent/utils"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"golang.org/x/sys/windows"
@@ -67,6 +68,11 @@ func (j *CredsJob) writeRootCACert(_ context.Context, cacert []byte, outputFile 
 
 	if err := utils.SaferWriteFile(cacert, outputFile, 0644); err != nil {
 		return err
+	}
+
+	if !cfg.Get().MDS.UpdateCACertificatesEnabled {
+		logger.Debugf("Skipping system store update as it is disabled in the configuration")
+		return nil
 	}
 
 	x509Cert, err := parseCertificate(cacert)

--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -94,6 +94,7 @@ cert_authentication = true
 
 [MDS]
 mtls_bootstrapping_enabled = true
+cacertificates_update_enabled = true
 
 [Snapshots]
 enabled = false
@@ -257,6 +258,9 @@ type OSLogin struct {
 type MDS struct {
 	// MTLSBootstrappingEnabled enables/disables the mTLS credential refresher.
 	MTLSBootstrappingEnabled bool `ini:"mtls_bootstrapping_enabled,omitempty"`
+	// UpdateCACertificatesEnabled enables/disables any updates to the CA certificates.
+	// These updates are done using tools like update-ca-certificates or similar.
+	UpdateCACertificatesEnabled bool `ini:"cacertificates_update_enabled,omitempty"`
 }
 
 // NetworkInterfaces contains the configurations of NetworkInterfaces section.


### PR DESCRIPTION
Agent is writing certs on disk along with updating the root trust store, add a configuration toggle to disable system cacerts update instead of having to disable whole feature. With this users can still use the feature by using certs from `/run/google-mds-mtls` 