### PR TITLE
Make primary nic management config consistent across all network managers

### DIFF
--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -420,6 +420,9 @@ func runDhclient(ctx context.Context, ipVersion ipVersion, nic string, release b
 // The first list contains interfaces for which to obtain an IPv4 lease.
 // The second list contains interfaces for which to obtain an IPv6 lease.
 // The third list contains interfaces for which to release their IPv6 lease.
+// It will skip primary NIC for IPv4 if process is already running or disabled via config.
+// Secondary NICs will be configured as long as there's no already existing dhclient
+// process managing it.
 func partitionInterfaces(ctx context.Context, interfaces, ipv6Interfaces []string) ([]string, []string, []string, error) {
 	var obtainIpv4Interfaces []string
 	var obtainIpv6Interfaces []string
@@ -428,6 +431,7 @@ func partitionInterfaces(ctx context.Context, interfaces, ipv6Interfaces []strin
 	for i, iface := range interfaces {
 		if !shouldManageInterface(i == 0) {
 			// Do not setup anything for this interface to avoid duplicate processes.
+			logger.Debugf("ManagePrimaryNIC is disabled, skipping dhclient launch for %s", iface)
 			continue
 		}
 

--- a/google_guest_agent/network/manager/netplan_linux.go
+++ b/google_guest_agent/network/manager/netplan_linux.go
@@ -208,6 +208,7 @@ func (n netplan) writeNetworkdDropin(interfaces, ipv6Interfaces []string) error 
 
 	for i, iface := range interfaces {
 		if !shouldManageInterface(i == 0) {
+			logger.Debugf("ManagePrimaryNIC is disabled, skipping writeNetworkdDropin for %s", iface)
 			continue
 		}
 		logger.Debugf("writing systemd-networkd drop-in config for %s", iface)
@@ -295,6 +296,7 @@ func (n netplan) writeNetplanEthernetDropin(mtuMap map[string]int, interfaces, i
 
 	for i, iface := range interfaces {
 		if !shouldManageInterface(i == 0) {
+			logger.Debugf("ManagePrimaryNIC is disabled, skipping writeNetplanEthernetDropin for %s", iface)
 			continue
 		}
 		logger.Debugf("Adding %s(%d) to drop-in configuration.", iface, i)

--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -170,7 +170,12 @@ func (n networkManager) ifcfgFilePath(iface string) string {
 func (n networkManager) writeNetworkManagerConfigs(ifaces []string) ([]string, error) {
 	var result []string
 
-	for _, iface := range ifaces {
+	for i, iface := range ifaces {
+		if !shouldManageInterface(i == 0) {
+			logger.Debugf("ManagePrimaryNIC is disabled, skipping writeNetworkManagerConfigs for %s", iface)
+			continue
+		}
+
 		logger.Debugf("writing nmconnection file for %s", iface)
 
 		configFilePath := n.networkManagerConfigFilePath(iface)

--- a/google_guest_agent/network/manager/systemd_networkd_linux.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux.go
@@ -499,6 +499,11 @@ func (sc systemdConfig) isGuestAgentManaged() bool {
 // provided directory using the given priority.
 func (n systemdNetworkd) writeEthernetConfig(interfaces, ipv6Interfaces []string) error {
 	for i, iface := range interfaces {
+		if !shouldManageInterface(i == 0) {
+			logger.Debugf("ManagePrimaryNIC is disabled, skipping systemdNetworkd writeEthernetConfig for %s", iface)
+			continue
+		}
+
 		logger.Debugf("write systemd-networkd network config for %s", iface)
 
 		var dhcp = "ipv4"


### PR DESCRIPTION
We introduced a config to control guest-agent's behavior of managing primary nic, apply that for all supported network managers

/cc @a-crate @dorileo @drewhli 