### PR TITLE
Allow users to enable/disable the mds mtls via metadata key

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Refer [this](https://cloud.google.com/compute/docs/metadata/overview#https-mds)
 for more information on HTTPS metadata server endpoint and credential details 
 including their lifespan.
 
-Credentials are stored at these locations - 
+Credentials can be stored at these supported locations - 
 
 * Linux: 
 
@@ -201,16 +201,26 @@ Credentials are stored at these locations -
     `Cert:\LocalMachine\Root`
     - [PFX](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/personal-information-exchange---pfx--files): `C:\ProgramData\Google\Compute Engine\mds-mtls-client.key.pfx`
 
-    *Credentials are stored on disk as well as in [Certificate Store](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores) on Windows*
+    *Credentials can be stored on disk as well as in [Certificate Store](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/certificate-stores) on Windows*
 
-Note that this is enabled automatically if HTTPS endpoint is supported on a VM. This
-can be disabled by setting `mtls_bootstrapping_enabled = false` under `[MDS]` section
+Note that this is disabled by default, if HTTPS endpoint is supported on a VM, the feature
+can be enabled by setting `disable-https-mds-setup = false` under `[MDS]` section
 in `instance_configs.cfg` file. 
 
-Local root trust store is updated by running `update-ca-certificates` or `update-ca-trust` 
-tool based on the OS or by adding cert to `Cert:\LocalMachine\Root` on Windows. This can be
-separately disabled by setting `cacertificates_update_enabled = false` in under the same
-`MDS` section.
+If enabled, agent will write certificates only on disk by default and users can
+opt-in to have certificates in OS Native stores. This means in case of Linux based VMs
+MDS Root certificate will be added to trust store like 
+`/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` on RHEL based systems 
+and `/etc/ssl/certs/ca-certificates.crt` on Debian based. Local root trust store 
+is updated by running `update-ca-certificates` or `update-ca-trust` tool based on the OS.
+On Windows, Client credentials will be added in `Cert:\LocalMachine\My` and Root
+certificate in `Cert:\LocalMachine\Root`. This can be enabled by setting `https-mds-skip-native-cert-store = false` under same `[MDS]` section.
+
+> As documented by Microsoft [here](https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/enable-ldap-over-ssl-3rd-certification-authority#possible-issues) there
+could be issues with LDAPS process when multiple certificates are added in personal
+store. Avoid enabling OS Native stores on Domain Controllers. Credentials can still
+be used from disk if required.
+
 
 ## Metadata Scripts
 

--- a/google_guest_agent/agentcrypto/mtls_mds_linux.go
+++ b/google_guest_agent/agentcrypto/mtls_mds_linux.go
@@ -59,6 +59,11 @@ func (j *CredsJob) writeRootCACert(ctx context.Context, content []byte, outputFi
 		return err
 	}
 
+	if !j.useNativeStore.Load() {
+		logger.Debugf("SkipNativeStore is enabled, will not write root cert to system store")
+		return nil
+	}
+
 	// Best effort to update system store, don't fail.
 	if err := updateSystemStore(ctx, outputFile); err != nil {
 		logger.Errorf("Failed add Root MDS cert to system trust store with error: %v", err)

--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -93,7 +93,8 @@ manage_primary_nic =
 cert_authentication = true
 
 [MDS]
-mtls_bootstrapping_enabled = true
+disable-https-mds-setup = true
+https-mds-skip-native-cert-store = true
 
 [Snapshots]
 enabled = false
@@ -253,10 +254,17 @@ type OSLogin struct {
 	CertAuthentication bool `ini:"cert_authentication,omitempty"`
 }
 
-// MDS contains the configurations for MDS section.
+// MDS contains the configurations for MDS section. Currently its opt-in only
+// and should not assume any defaults. Setting any [defaultConfig] values will
+// override user settings from Metadata.
 type MDS struct {
-	// MTLSBootstrappingEnabled enables/disables the mTLS credential refresher.
-	MTLSBootstrappingEnabled bool `ini:"mtls_bootstrapping_enabled,omitempty"`
+	// DisableHTTPSMdsSetup enables/disables the mTLS credential refresher.
+	DisableHTTPSMdsSetup bool `ini:"disable-https-mds-setup,omitempty"`
+	// HTTPSMDSSkipNativeStore enables/disables the use of OSs native store. Native
+	// store is Certificate Store on Windows which hosts both Client Credential and
+	// Root certificate where as its trust store that hosts root certs like
+	// `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` on Linux.
+	HTTPSMDSSkipNativeStore bool `ini:"https-mds-skip-native-cert-store,omitempty"`
 }
 
 // NetworkInterfaces contains the configurations of NetworkInterfaces section.

--- a/google_guest_agent/instance_setup.go
+++ b/google_guest_agent/instance_setup.go
@@ -29,7 +29,6 @@ import (
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	network "github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/network/manager"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
-	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/scheduler"
 	"github.com/GoogleCloudPlatform/guest-agent/retry"
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"github.com/go-ini/ini"
@@ -227,9 +226,7 @@ func agentInit(ctx context.Context) {
 	// use them. Processes may depend on the Guest Agent at startup to ensure that the credentials are
 	// available for use. By generating the credentials before notifying the systemd, we ensure that
 	// they are generated for any process that depends on the Guest Agent.
-	if config.MDS.MTLSBootstrappingEnabled {
-		scheduler.ScheduleJobs(ctx, []scheduler.Job{agentcrypto.New()}, true)
-	}
+	agentcrypto.Init(ctx)
 }
 
 func generateSSHKeys(ctx context.Context) error {

--- a/google_guest_agent/scheduler/scheduler.go
+++ b/google_guest_agent/scheduler/scheduler.go
@@ -186,3 +186,12 @@ func ScheduleJobs(ctx context.Context, jobs []Job, synchronous bool) {
 		wg.Wait()
 	}
 }
+
+// IsScheduled returns true if job was scheduled.
+func (s *Scheduler) IsScheduled(jobID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, found := s.jobs[jobID]
+	return found
+}

--- a/google_guest_agent/scheduler/scheduler_test.go
+++ b/google_guest_agent/scheduler/scheduler_test.go
@@ -65,8 +65,8 @@ func TestSchedule(t *testing.T) {
 
 	s.start()
 
-	if _, ok := s.jobs[job.ID()]; !ok {
-		t.Errorf("Failed to schedule %s, expected an entry in scheduled jobs", job.ID())
+	if !s.IsScheduled(job.ID()) {
+		t.Errorf("IsScheduled(%s) = false, want true", job.ID())
 	}
 
 	time.Sleep(3 * time.Second)
@@ -108,11 +108,11 @@ func TestMultipleSchedules(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	s.UnscheduleJob(job2.ID())
 
-	if _, ok := s.jobs[job1.ID()]; !ok {
-		t.Errorf("Failed to schedule %s, expected an entry in scheduled jobs", job1.ID())
+	if !s.IsScheduled(job1.ID()) {
+		t.Errorf("IsScheduled(%s) = false, want true", job1.ID())
 	}
-	if _, ok := s.jobs[job2.ID()]; ok {
-		t.Errorf("Failed to unschedule %s, found an entry in scheduled jobs", job2.ID())
+	if s.IsScheduled(job2.ID()) {
+		t.Errorf("IsScheduled(%s) = true, want false", job2.ID())
 	}
 
 	time.Sleep(time.Second)
@@ -142,8 +142,8 @@ func TestStopSchedule(t *testing.T) {
 		t.Errorf("AddJob(%s) failed unexecptedly with error: %v", job.ID(), err)
 	}
 
-	if _, ok := s.jobs[job.ID()]; !ok {
-		t.Errorf("Failed to schedule %s, expected an entry in scheduled jobs", job.ID())
+	if !s.IsScheduled(job.ID()) {
+		t.Errorf("IsScheduled(%s) = false, want true", job.ID())
 	}
 
 	time.Sleep(3 * time.Second)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -202,22 +202,24 @@ type Project struct {
 
 // Attributes describes the project's attributes keys.
 type Attributes struct {
-	BlockProjectKeys      bool
-	EnableOSLogin         *bool
-	EnableWindowsSSH      *bool
-	TwoFactor             *bool
-	SecurityKey           *bool
-	RequireCerts          *bool
-	SSHKeys               []string
-	WindowsKeys           WindowsKeys
-	Diagnostics           string
-	DisableAddressManager *bool
-	DisableAccountManager *bool
-	EnableDiagnostics     *bool
-	EnableWSFC            *bool
-	WSFCAddresses         string
-	WSFCAgentPort         string
-	DisableTelemetry      bool
+	BlockProjectKeys        bool
+	HTTPSMDSSkipNativeStore *bool
+	DisableHTTPSMdsSetup    *bool
+	EnableOSLogin           *bool
+	EnableWindowsSSH        *bool
+	TwoFactor               *bool
+	SecurityKey             *bool
+	RequireCerts            *bool
+	SSHKeys                 []string
+	WindowsKeys             WindowsKeys
+	Diagnostics             string
+	DisableAddressManager   *bool
+	DisableAccountManager   *bool
+	EnableDiagnostics       *bool
+	EnableWSFC              *bool
+	WSFCAddresses           string
+	WSFCAgentPort           string
+	DisableTelemetry        bool
 }
 
 // UnmarshalJSON unmarshals b into Attribute.
@@ -229,23 +231,25 @@ func (a *Attributes) UnmarshalJSON(b []byte) error {
 	}
 	// Unmarshal to literal JSON types before doing anything else.
 	type inner struct {
-		BlockProjectKeys      string      `json:"block-project-ssh-keys"`
-		Diagnostics           string      `json:"diagnostics"`
-		DisableAccountManager string      `json:"disable-account-manager"`
-		DisableAddressManager string      `json:"disable-address-manager"`
-		EnableDiagnostics     string      `json:"enable-diagnostics"`
-		EnableOSLogin         string      `json:"enable-oslogin"`
-		EnableWindowsSSH      string      `json:"enable-windows-ssh"`
-		EnableWSFC            string      `json:"enable-wsfc"`
-		OldSSHKeys            string      `json:"sshKeys"`
-		SSHKeys               string      `json:"ssh-keys"`
-		TwoFactor             string      `json:"enable-oslogin-2fa"`
-		SecurityKey           string      `json:"enable-oslogin-sk"`
-		RequireCerts          string      `json:"enable-oslogin-certificates"`
-		WindowsKeys           WindowsKeys `json:"windows-keys"`
-		WSFCAddresses         string      `json:"wsfc-addrs"`
-		WSFCAgentPort         string      `json:"wsfc-agent-port"`
-		DisableTelemetry      string      `json:"disable-guest-telemetry"`
+		BlockProjectKeys        string      `json:"block-project-ssh-keys"`
+		Diagnostics             string      `json:"diagnostics"`
+		DisableAccountManager   string      `json:"disable-account-manager"`
+		DisableAddressManager   string      `json:"disable-address-manager"`
+		EnableDiagnostics       string      `json:"enable-diagnostics"`
+		EnableOSLogin           string      `json:"enable-oslogin"`
+		EnableWindowsSSH        string      `json:"enable-windows-ssh"`
+		EnableWSFC              string      `json:"enable-wsfc"`
+		OldSSHKeys              string      `json:"sshKeys"`
+		SSHKeys                 string      `json:"ssh-keys"`
+		TwoFactor               string      `json:"enable-oslogin-2fa"`
+		SecurityKey             string      `json:"enable-oslogin-sk"`
+		RequireCerts            string      `json:"enable-oslogin-certificates"`
+		WindowsKeys             WindowsKeys `json:"windows-keys"`
+		WSFCAddresses           string      `json:"wsfc-addrs"`
+		WSFCAgentPort           string      `json:"wsfc-agent-port"`
+		DisableTelemetry        string      `json:"disable-guest-telemetry"`
+		DisableHTTPSMdsSetup    string      `json:"disable-https-mds-setup"`
+		HTTPSMDSSkipNativeStore string      `json:"https-mds-skip-native-cert-store"`
 	}
 	var temp inner
 	if err := json.Unmarshal(b, &temp); err != nil {
@@ -256,7 +260,15 @@ func (a *Attributes) UnmarshalJSON(b []byte) error {
 	a.WSFCAgentPort = temp.WSFCAgentPort
 	a.WindowsKeys = temp.WindowsKeys
 
-	value, err := strconv.ParseBool(temp.BlockProjectKeys)
+	value, err := strconv.ParseBool(temp.DisableHTTPSMdsSetup)
+	if err == nil {
+		a.DisableHTTPSMdsSetup = mkbool(value)
+	}
+	value, err = strconv.ParseBool(temp.HTTPSMDSSkipNativeStore)
+	if err == nil {
+		a.HTTPSMDSSkipNativeStore = mkbool(value)
+	}
+	value, err = strconv.ParseBool(temp.BlockProjectKeys)
 	if err == nil {
 		a.BlockProjectKeys = value
 	}


### PR DESCRIPTION
* Allows users to configure mds mtls feature using config file and metadata keys
* Make keys consistent across config file and metadata for easier use
* `syscall.StringToUTF16Ptr` is deprecated, update to use newer way 

/cc @dorileo @drewhli 