### PR TITLE
Fix debian12 netplan config issue, use ptr receiver

### DIFF
--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -157,18 +157,18 @@ type ipVersion struct {
 type dhclient struct{}
 
 // Name returns the name of the network manager service.
-func (n dhclient) Name() string {
+func (n *dhclient) Name() string {
 	return "dhclient"
 }
 
 // Configure gives the opportunity for the Service implementation to adjust its configuration
 // based on the Guest Agent configuration.
-func (n dhclient) Configure(ctx context.Context, config *cfg.Sections) {
+func (n *dhclient) Configure(ctx context.Context, config *cfg.Sections) {
 }
 
 // isDhclientInstalled returns true if the dhclient binary/executable is
 // installed in the running system.
-func (n dhclient) isDhclientInstalled() (bool, error) {
+func (n *dhclient) isDhclientInstalled() (bool, error) {
 	if _, err := execLookPath("dhclient"); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return false, nil
@@ -179,13 +179,13 @@ func (n dhclient) isDhclientInstalled() (bool, error) {
 }
 
 // IsManaging checks if the dhclient CLI is available.
-func (n dhclient) IsManaging(ctx context.Context, iface string) (bool, error) {
+func (n *dhclient) IsManaging(ctx context.Context, iface string) (bool, error) {
 	return n.isDhclientInstalled()
 }
 
 // SetupEthernetInterface sets up the non-primary interfaces with dhclient, having different setup procedures
 // for IPv6 network interfaces and IPv4 network interfaces.
-func (n dhclient) SetupEthernetInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
+func (n *dhclient) SetupEthernetInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
 	dhcpCommand := config.NetworkInterfaces.DHCPCommand
 	if dhcpCommand != "" {
 		tokens := strings.Split(dhcpCommand, " ")
@@ -243,7 +243,7 @@ func (n dhclient) SetupEthernetInterface(ctx context.Context, config *cfg.Sectio
 }
 
 // SetupVlanInterface calls the appropriate native commands to configure a vlan interface.
-func (n dhclient) SetupVlanInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
+func (n *dhclient) SetupVlanInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
 	logger.Debugf("vlans: %+v", nics.VlanInterfaces)
 
 	// Retrieves the ethernet nics so we can detect the parent one.
@@ -343,7 +343,7 @@ func (n dhclient) SetupVlanInterface(ctx context.Context, config *cfg.Sections, 
 	return nil
 }
 
-func (n dhclient) removeVlanInterfaces(ctx context.Context, keepMe []string) error {
+func (n *dhclient) removeVlanInterfaces(ctx context.Context, keepMe []string) error {
 	sysInterfaces, err := net.Interfaces()
 	if err != nil {
 		return fmt.Errorf("failed to list systems interfaces: %+v", err)
@@ -492,7 +492,7 @@ func dhclientProcessExists(_ context.Context, iface string, ipVersion ipVersion)
 }
 
 // Rollback releases all leases from DHClient, effectively undoing the dhclient configurations.
-func (n dhclient) Rollback(ctx context.Context, nics *Interfaces) error {
+func (n *dhclient) Rollback(ctx context.Context, nics *Interfaces) error {
 	// Determine if we can even rollback dhclient processes.
 	if isInstalled, err := n.isDhclientInstalled(); !isInstalled || err != nil {
 		logger.Debugf("No preconditions met for dhclient roll back, skipping.")

--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -82,7 +82,7 @@ type networkManager struct {
 }
 
 // Name is the name of this network manager service.
-func (n networkManager) Name() string {
+func (n *networkManager) Name() string {
 	return "NetworkManager"
 }
 
@@ -92,7 +92,7 @@ func (n *networkManager) Configure(ctx context.Context, config *cfg.Sections) {
 }
 
 // IsManaging checks if NetworkManager is managing the provided interface.
-func (n networkManager) IsManaging(ctx context.Context, iface string) (bool, error) {
+func (n *networkManager) IsManaging(ctx context.Context, iface string) (bool, error) {
 	// Check whether NetworkManager.service is active.
 	if err := run.Quiet(ctx, "systemctl", "is-active", "NetworkManager.service"); err != nil {
 		return false, nil
@@ -125,7 +125,7 @@ func (n networkManager) IsManaging(ctx context.Context, iface string) (bool, err
 }
 
 // Setup sets up the necessary configurations for NetworkManager.
-func (n networkManager) SetupEthernetInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
+func (n *networkManager) SetupEthernetInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
 	ifaces, err := interfaceNames(nics.EthernetInterfaces)
 	if err != nil {
 		return fmt.Errorf("error getting interfaces: %v", err)
@@ -153,21 +153,21 @@ func (n networkManager) SetupEthernetInterface(ctx context.Context, config *cfg.
 
 // SetupVlanInterface writes the apppropriate vLAN interfaces configuration for the network manager service
 // for all configured interfaces.
-func (n networkManager) SetupVlanInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
+func (n *networkManager) SetupVlanInterface(ctx context.Context, config *cfg.Sections, nics *Interfaces) error {
 	return nil
 }
 
 // networkManagerConfigFilePath gets the config file path for the provided interface.
-func (n networkManager) networkManagerConfigFilePath(iface string) string {
+func (n *networkManager) networkManagerConfigFilePath(iface string) string {
 	return path.Join(n.configDir, fmt.Sprintf("google-guest-agent-%s.nmconnection", iface))
 }
 
-func (n networkManager) ifcfgFilePath(iface string) string {
+func (n *networkManager) ifcfgFilePath(iface string) string {
 	return path.Join(n.networkScriptsDir, fmt.Sprintf("ifcfg-%s", iface))
 }
 
 // writeNetworkManagerConfigs writes the configuration files for NetworkManager.
-func (n networkManager) writeNetworkManagerConfigs(ifaces []string) ([]string, error) {
+func (n *networkManager) writeNetworkManagerConfigs(ifaces []string) ([]string, error) {
 	var result []string
 
 	for i, iface := range ifaces {
@@ -231,7 +231,7 @@ func (n networkManager) writeNetworkManagerConfigs(ifaces []string) ([]string, e
 }
 
 // Rollback deletes the configurations created by Setup().
-func (n networkManager) Rollback(ctx context.Context, nics *Interfaces) error {
+func (n *networkManager) Rollback(ctx context.Context, nics *Interfaces) error {
 	ifaces, err := interfaceNames(nics.EthernetInterfaces)
 	if err != nil {
 		return fmt.Errorf("getting interfaces: %v", err)


### PR DESCRIPTION
Default Debian 12 netplan config is very generic and was overriding the agent written config. PR implements a workaround until generic configs for all eth* and en* nics are removed from GCE images. 

For example - 

```
# Prefix drop-in directory with "-a" 
$ ls /etc/systemd/network
10-netplan-a-ens4.network.d  10-netplan-a-ens5.network.d

# Use prefix in keys
$ cat /run/netplan/20-google-guest-agent-ethernet.yaml
network:
    version: 2
    ethernets:
        a-ens4:
            match:
                name: ens4
<--config-->
        a-ens5:
            match:
                name: ens5
<--config-->

```

Instead of value, consistently use pointer receivers for all network manager implementations.

/cc @dorileo @drewhli 