### PR TITLE
Add VLAN NIC support for NetworkManager

### DIFF
--- a/google_guest_agent/network/manager/manager.go
+++ b/google_guest_agent/network/manager/manager.go
@@ -165,6 +165,7 @@ func SetupInterfaces(ctx context.Context, config *cfg.Sections, mds *metadata.De
 	}
 
 	if config.Unstable.VlanSetupEnabled {
+		logger.Infof("VLAN setup is enabled via config file, setting up interfaces")
 		if err = activeService.manager.SetupVlanInterface(ctx, config, nics); err != nil {
 			return fmt.Errorf("manager(%s): error setting up vlan interfaces: %v", activeService.manager.Name(), err)
 		}


### PR DESCRIPTION
If enabled via config file this adds support to configure VLAN NICs through `NetworkManager`.

Setup writes VLAN config at - `/etc/NetworkManager/system-connections/`. If VLAN with ID 5 is configured on eth0 it will write a file `google-guest-agent-gcp.eth0.5.nmconnection` in the directory. 

Interfaces are named as `gcp.<parent_interface_name>.<vlan_id>` and using it connections are named as `google-guest-agent-<interface_name>`

/cc @dorileo @drewhli 