### PR TITLE
Update Vlan interfaces format to match with MDS

### DIFF
--- a/google_guest_agent/network/manager/common.go
+++ b/google_guest_agent/network/manager/common.go
@@ -69,7 +69,7 @@ func vlanInterfaceParentMap(nics map[int]metadata.VlanInterface, allEthernetInte
 }
 
 // vlanInterfaceListsIpv6 gets a list of VLAN IDs that support IPv6.
-func vlanInterfaceListsIpv6(nics map[int]metadata.VlanInterface) []int {
+func vlanInterfaceListsIpv6(nics map[int]VlanInterface) []int {
 	var googleIpv6Interfaces []int
 
 	for _, ni := range nics {

--- a/google_guest_agent/network/manager/common_test.go
+++ b/google_guest_agent/network/manager/common_test.go
@@ -79,11 +79,11 @@ func TestVlanParentInterfaceFailure(t *testing.T) {
 }
 
 func TestVlanInterfaceListsIpv6(t *testing.T) {
-	nics := map[int]metadata.VlanInterface{
-		0: {Vlan: 4, DHCPv6Refresh: "123456"},
-		1: {Vlan: 5},
-		2: {Vlan: 6, MTU: 1234},
-		3: {Vlan: 7, Mac: "acd", ParentInterface: "/parent/0", DHCPv6Refresh: "7890"},
+	nics := map[int]VlanInterface{
+		0: {VlanInterface: metadata.VlanInterface{Vlan: 4, DHCPv6Refresh: "123456"}},
+		1: {VlanInterface: metadata.VlanInterface{Vlan: 5}},
+		2: {VlanInterface: metadata.VlanInterface{Vlan: 6, MTU: 1234}},
+		3: {VlanInterface: metadata.VlanInterface{Vlan: 7, Mac: "acd", ParentInterface: "/parent/0", DHCPv6Refresh: "7890"}},
 	}
 	want := []int{4, 7}
 	got := vlanInterfaceListsIpv6(nics)

--- a/google_guest_agent/network/manager/netplan_linux_test.go
+++ b/google_guest_agent/network/manager/netplan_linux_test.go
@@ -191,20 +191,24 @@ func TestSetupVlanInterface(t *testing.T) {
 				Mac: ifaces[1].HardwareAddr.String(),
 			},
 		},
-		VlanInterfaces: map[int]metadata.VlanInterface{
+		VlanInterfaces: map[int]VlanInterface{
 			5: {
-				ParentInterface: "/computeMetadata/v1/instance/network-interfaces/0/",
-				Mac:             "mac-address",
-				Vlan:            5,
-				MTU:             1460,
+				VlanInterface: metadata.VlanInterface{
+					Mac:  "mac-address",
+					Vlan: 5,
+					MTU:  1460,
+				},
+				ParentInterfaceID: ifaces[1].Name,
 			},
 			6: {
-				ParentInterface: "/computeMetadata/v1/instance/network-interfaces/0/",
-				Mac:             "mac-address2",
-				Vlan:            6,
-				MTU:             1500,
-				IPv6:            []string{"::0"},
-				DHCPv6Refresh:   "123456",
+				VlanInterface: metadata.VlanInterface{
+					Mac:           "mac-address2",
+					Vlan:          6,
+					MTU:           1500,
+					IPv6:          []string{"::0"},
+					DHCPv6Refresh: "123456",
+				},
+				ParentInterfaceID: ifaces[1].Name,
 			},
 		},
 	}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -148,7 +148,7 @@ type Instance struct {
 	NetworkInterfaces []NetworkInterfaces
 
 	// VlanNetworkInterfaces contains all the vLAN network interfaces.
-	VlanNetworkInterfaces []map[int]VlanInterface
+	VlanNetworkInterfaces map[int]map[int]VlanInterface
 
 	// VirtualClock contains the drift-token attribute.
 	VirtualClock virtualClock


### PR DESCRIPTION
MDS response format for VLAN NICs has changed from - 

```
[
   {<vlan-id>: {...}, <vlan-id>: {...}}, // <--- nic0 parent
   {<vlan-id>: {...}}                    // <--- nic1 parent
]
```
to
```
{
   0: {<vlan-id>: {...}, <vlan-id>: {...}}
   1: {<vlan-id>: {...}}
}
```
- Updates VLAN interface data structure to match what MDS returns
- Update network manager `VlanInterface` for easier handling of parent interface name, every network manager doesn't need to handle it thus avoiding duplicate code.
- Refactored code to honor this new data structure

/cc @dorileo @drewhli 