### PR TITLE
network: remove primary NIC left over configs.

### DIFF
--- a/google_guest_agent/network/manager/manager_test.go
+++ b/google_guest_agent/network/manager/manager_test.go
@@ -90,6 +90,11 @@ func (n *mockService) Rollback(context.Context, *Interfaces) error {
 	return nil
 }
 
+// RollbackNics implements the Service interface.
+func (n *mockService) RollbackNics(ctx context.Context, nics *Interfaces) error {
+	return n.Rollback(ctx, nics)
+}
+
 // managerTestSetup does pre-test setup steps.
 func managerTestSetup() {
 	// Clear the known network managers and fallbacks.


### PR DESCRIPTION
If we are not managing the primary NIC configurations attempt to
remove any orphaned/unmanaged configuration guest-agent may have
left behind.

It's applied to all possible network managers supported considering
the user may have manually switched between default network manager
framework over the time.

This cleanup routine is performed *only* if the user's not set the
configuration instructing guest-agent to manage the primary NIC,
namely (NetworkInterfaces.manage_primary_nic).