### PR TITLE
network: restore debian-12 netplan configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ NetworkInterfaces | setup                  | `false` skips network interface set
 NetworkInterfaces | ip\_forwarding         | `false` skips IP forwarding.
 NetworkInterfaces | manage\_primary\_nic   | `true` will start managing the primary NIC in addition to the secondary NICs.
 NetworkInterfaces | dhcp\_command          | String path for alternate dhcp executable used to enable network interfaces.
+NetworkInterfaces | restore_debian12_netplan_config | `true` will create the debian-12's default netplan  configuration. It's set `true` by default.
 OSLogin           | cert_authentication    | `false` prevents guest-agent from setting up sshd's `TrustedUserCAKeys`, `AuthorizedPrincipalsCommand` and `AuthorizedPrincipalsCommandUser` configuration keys. Default value: `true`.
 
 Setting `network_enabled` to `false` will disable generating host keys and the

--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -91,6 +91,7 @@ dhcp_command =
 ip_forwarding = true
 setup = true
 manage_primary_nic =
+restore_debian12_netplan_config = true
 
 [OSLogin]
 cert_authentication = true
@@ -282,10 +283,11 @@ type MDS struct {
 
 // NetworkInterfaces contains the configurations of NetworkInterfaces section.
 type NetworkInterfaces struct {
-	DHCPCommand      string `ini:"dhcp_command,omitempty"`
-	IPForwarding     bool   `ini:"ip_forwarding,omitempty"`
-	Setup            bool   `ini:"setup,omitempty"`
-	ManagePrimaryNIC bool   `ini:"manage_primary_nic,omitempty"`
+	DHCPCommand                  string `ini:"dhcp_command,omitempty"`
+	IPForwarding                 bool   `ini:"ip_forwarding,omitempty"`
+	Setup                        bool   `ini:"setup,omitempty"`
+	ManagePrimaryNIC             bool   `ini:"manage_primary_nic,omitempty"`
+	RestoreDebian12NetplanConfig bool   `ini:"restore_debian12_netplan_config,omitempty"`
 }
 
 // Snapshots contains the configurations of Snapshots section.


### PR DESCRIPTION
In a previous release guest-agent team introduced a code path that removed the debian-12's netplan default configuration instead of overriding it.

This change makes sure the default configuration is re-created and bring it consistent to the default experience of debian-12 images.

Additionally a new configuration key was introduced to allow users to prevent guest-agent creating the configuration:
   NetworkInterfaces.restore_debian12_netplan_config

The new configuration is set to true by default.