### PR TITLE
Log interface state after setting up network

### DIFF
--- a/google_guest_agent/network/manager/manager.go
+++ b/google_guest_agent/network/manager/manager.go
@@ -227,6 +227,8 @@ func SetupInterfaces(ctx context.Context, config *cfg.Sections, mds *metadata.De
 
 	logger.Infof("Finished setting up %s", activeService.manager.Name())
 
+	logInterfaceState(ctx)
+
 	return nil
 }
 


### PR DESCRIPTION
Captures the network interface status after the network setup completes to help diagnose if any issue arise.

/cc @dorileo @drewhli 