### PR TITLE
Retry MDS PUT operation, reload netplan/networkctl only if configs are changed

### DIFF
--- a/google_guest_agent/network/manager/common.go
+++ b/google_guest_agent/network/manager/common.go
@@ -18,6 +18,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -40,6 +41,18 @@ var (
 	// execLookPath points to the function to check if a path exists.
 	execLookPath = exec.LookPath
 )
+
+func cliExists(name string) (bool, error) {
+	_, err := execLookPath(name)
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.Is(err, exec.ErrNotFound) {
+		return false, nil
+	}
+	return false, fmt.Errorf("error looking up path for %q: %v", name, err)
+}
 
 // logInterfaceState logs all network interface state present on the machine.
 func logInterfaceState(ctx context.Context) {

--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -18,10 +18,8 @@ package manager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
-	"os/exec"
 	"path"
 	"regexp"
 	"slices"
@@ -169,13 +167,7 @@ func (n *dhclient) Configure(ctx context.Context, config *cfg.Sections) {
 // isDhclientInstalled returns true if the dhclient binary/executable is
 // installed in the running system.
 func (n *dhclient) isDhclientInstalled() (bool, error) {
-	if _, err := execLookPath("dhclient"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error looking up dhclient path: %v", err)
-	}
-	return true, nil
+	return cliExists("dhclient")
 }
 
 // IsManaging checks if the dhclient CLI is available.

--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -18,10 +18,8 @@ package manager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -145,11 +143,9 @@ func (n *networkManager) IsManaging(ctx context.Context, iface string) (bool, er
 
 	// Check for existence of nmcli. Without nmcli, the agent cannot tell NetworkManager
 	// to reload the configs for its connections.
-	if _, err := execLookPath("nmcli"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error checking for nmcli: %v", err)
+	_, err := cliExists("nmcli")
+	if err != nil {
+		return false, err
 	}
 
 	// Use nmcli to check status of provided  interface.

--- a/google_guest_agent/network/manager/network_manager_linux_test.go
+++ b/google_guest_agent/network/manager/network_manager_linux_test.go
@@ -213,7 +213,7 @@ func TestNetworkManagerIsManaging(t *testing.T) {
 			},
 			expectedRes: false,
 			expectErr:   true,
-			expectedErr: "error checking for nmcli: mock error lookpath",
+			expectedErr: `error looking up path for "nmcli": mock error lookpath`,
 		},
 		// 'systemctl is-active NetworkManager.service' error.
 		{

--- a/google_guest_agent/network/manager/systemd_networkd_linux.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux.go
@@ -19,10 +19,8 @@ package manager
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -188,12 +186,11 @@ func (n *systemdNetworkd) Configure(ctx context.Context, config *cfg.Sections) {
 // to check if systemd-networkd is managing or has configured the provided interface.
 func (n *systemdNetworkd) IsManaging(ctx context.Context, iface string) (bool, error) {
 	// Check the version.
-	if _, err := execLookPath("networkctl"); err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error looking up networkctl path: %v", err)
+	_, err := cliExists("networkctl")
+	if err != nil {
+		return false, err
 	}
+
 	res := run.WithOutput(ctx, "networkctl", "--version")
 	if res.ExitCode != 0 {
 		return false, fmt.Errorf("error checking networkctl version: %v", res.StdErr)

--- a/google_guest_agent/network/manager/systemd_networkd_linux_test.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux_test.go
@@ -261,7 +261,7 @@ func TestSystemdNetworkdIsManaging(t *testing.T) {
 			},
 			expectedRes: false,
 			expectErr:   true,
-			expectedErr: "error looking up networkctl path: mock error finding path",
+			expectedErr: `error looking up path for "networkctl": mock error finding path`,
 		},
 		// networkctl unsupported version
 		{


### PR DESCRIPTION
- Adds retry logic for MDS PUT operation to avoid flaky failures
- Consolidates logic of checking CLI existence across network managers in one function to avoid duplication
- To avoid unnecessary DHCP refresh, now agent does `networkctl reload` and `netplan apply` only if configs are really added/removed by agent
- Errors occurred during `Rollback` might not be real issues as we run rollback on all network managers, downgraded logs from error to warning to avoid concerns 

/cc @dorileo @drewhli 