### PR TITLE
network: only trigger networkctl reload for specific interface

### DIFF
--- a/google_guest_agent/network/manager/systemd_networkd_linux_test.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux_test.go
@@ -511,12 +511,13 @@ func TestSystemdNetworkdConfig(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg.Get().NetworkInterfaces.ManagePrimaryNIC = test.managePrimary
 			systemdTestSetup(t, systemdTestOpts{})
 
-			if err := mockSystemd.writeEthernetConfig(test.testInterfaces, test.testIpv6Interfaces); err != nil {
+			if err := mockSystemd.writeEthernetConfig(ctx, test.testInterfaces, test.testIpv6Interfaces); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 


### PR DESCRIPTION
Instead of blindly reloading all network configurations with networkctl reload we now provide the interface name we want to have reload - that avoids disturbing network configurations not touched our managed by guest-agent.

For now we are accounting only for the regular interface configuration, vLAN interfaces and the rollback code paths are intentionally unchanged.