### PR TITLE
network/netplan: do generate instead of apply

### DIFF
--- a/google_guest_agent/network/manager/netplan_linux.go
+++ b/google_guest_agent/network/manager/netplan_linux.go
@@ -222,14 +222,14 @@ func (n *netplan) SetupEthernetInterface(ctx context.Context, config *cfg.Sectio
 func (n *netplan) reloadConfigs(ctx context.Context) error {
 	logger.Infof("Reloading netplan configs...")
 
+	// Avoid restarting netplan.
+	if err := run.Quiet(ctx, "netplan", "generate"); err != nil {
+		return fmt.Errorf("error generating netplan based config: %w", err)
+	}
+
 	// Avoid restarting systemd-networkd.
 	if err := run.Quiet(ctx, "networkctl", "reload"); err != nil {
 		return fmt.Errorf("error reloading systemd-networkd network configs: %v", err)
-	}
-
-	// Avoid restarting netplan.
-	if err := run.Quiet(ctx, "netplan", "apply"); err != nil {
-		return fmt.Errorf("error applying netplan changes: %w", err)
 	}
 
 	return nil

--- a/google_guest_agent/network/manager/netplan_linux_test.go
+++ b/google_guest_agent/network/manager/netplan_linux_test.go
@@ -219,7 +219,7 @@ func TestSetupVlanInterface(t *testing.T) {
 		t.Errorf("SetupVlanInterface(ctx, nil, %+v) failed unexpectedly with error: %v", nics, err)
 	}
 
-	wantCmds := []string{"netplan apply", "networkctl reload"}
+	wantCmds := []string{"netplan generate", "networkctl reload"}
 	gotCmds := runner.executedCommands
 	sort.Strings(gotCmds)
 


### PR DESCRIPTION
We don't want to rely on netplan's apply operation as it will do more than we expect to the interfaces we are managing. Instead we use generate operation and we manage the reload from our side.