### PR TITLE
Avoid unnecessary reloads, check before overwriting configs

### DIFF
--- a/google_guest_agent/network/manager/common.go
+++ b/google_guest_agent/network/manager/common.go
@@ -262,3 +262,13 @@ func readYamlFile(filepath string, ptr any) error {
 
 	return yaml.Unmarshal(bytes, ptr)
 }
+
+// fileExists returns true only if file exists and it can successfully run stat
+// on the path.
+func fileExists(filepath string) bool {
+	s, err := os.Stat(filepath)
+	if err != nil && !errors.Is(os.ErrNotExist, err) {
+		return false
+	}
+	return !s.IsDir()
+}

--- a/google_guest_agent/network/manager/common_test.go
+++ b/google_guest_agent/network/manager/common_test.go
@@ -16,6 +16,8 @@ package manager
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -132,6 +134,45 @@ func TestVlanInterfaceParentMap(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.wantMap, got); diff != "" {
 				t.Errorf("vlanInterfaceParentMap(%+v, %v) returned unexpected diff (-want,+got)\n%s", test.nics, test.allEthernetInterfaces, diff)
+			}
+		})
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "file")
+	if err != nil {
+		t.Fatalf("os.CreateTemp(%s, file) failed unexpectedly with error: %v", dir, err)
+	}
+	defer f.Close()
+
+	tests := []struct {
+		name string
+		want bool
+		path string
+	}{
+		{
+			name: "existing_file",
+			want: true,
+			path: f.Name(),
+		},
+		{
+			name: "existing_dir",
+			want: false,
+			path: dir,
+		},
+		{
+			name: "non_existing_file",
+			want: false,
+			path: filepath.Join(t.TempDir(), "random"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := fileExists(test.path); got != test.want {
+				t.Errorf("fileExists(%s) = %t, want = %t", test.path, got, test.want)
 			}
 		})
 	}

--- a/google_guest_agent/network/manager/manager_linux.go
+++ b/google_guest_agent/network/manager/manager_linux.go
@@ -19,7 +19,7 @@ func init() {
 	knownNetworkManagers = []Service{
 		&netplan{
 			netplanConfigDir:  "/run/netplan/",
-			networkdDropinDir: "/etc/systemd/network/",
+			networkdDropinDir: "/run/systemd/network/",
 			priority:          20,
 		},
 		&wicked{


### PR DESCRIPTION
To prevent brief network interruptions during network reloads, ensure configuration changes are only applied when necessary. This avoids unnecessary DHCP lease releases and renewals, which can disrupt network connectivity.

/cc @dorileo @drewhli 