### PR TITLE
Skip linklocal settings on ubuntu 20.04

### DIFF
--- a/google_guest_agent/network/manager/netplan_linux.go
+++ b/google_guest_agent/network/manager/netplan_linux.go
@@ -360,6 +360,12 @@ func (n *netplan) writeNetplanEthernetDropin(mtuMap map[string]int, interfaces, 
 		},
 	}
 
+	info := osinfo.Get()
+	var defaultLinklocal bool
+	if info.OS == "ubuntu" && info.VersionID == "20.04" {
+		defaultLinklocal = true
+	}
+
 	for i, iface := range interfaces {
 		if !shouldManageInterface(i == 0) {
 			logger.Debugf("ManagePrimaryNIC is disabled, skipping writeNetplanEthernetDropin for %s", iface)
@@ -387,6 +393,12 @@ func (n *netplan) writeNetplanEthernetDropin(mtuMap map[string]int, interfaces, 
 				UseDomains: shouldUseDomains(i),
 			}
 			ne.LinkLocal = append(ne.LinkLocal, "ipv6")
+		}
+
+		if defaultLinklocal {
+			logger.Infof("Running on OS: %q, will skip setting LinkLocal", osinfo.Get().PrettyName)
+			// Set it to nil and let it fallback to default.
+			ne.LinkLocal = nil
 		}
 
 		key := n.ID(iface)


### PR DESCRIPTION
Do not set LinkLocal on Ubuntu 20.04 it ends up adding route to MDS on secondary NIC which breaks all calls to MDS with error `dial tcp 169.254.169.254:80: i/o timeout`
/cc @dorileo @drewhli 