### PR TITLE
SUSE no overwrite bug fix, ubuntu 18.04 exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ are written.
 If none of the first 4 network manager services are detected on the system, then
 the agent will default to using `dhclient` for managing network interfaces.
 
+Note: Ubuntu 18.04, while having `netplan` installed,  ships a outdated and 
+unsupported version of `networkctl`. This older version lacks essential commands like 
+`networkctl reload`, causing compatibility issues. Guest agent is designed to 
+fallback to dhclient on Ubuntu 18.04, even when netplan is present, to ensure proper
+network configuration.
+
 The following configuration flags can control the behavior:
 
 *   `manage_primary_nic`: When enabled, the agent will start managing the

--- a/google_guest_agent/network/manager/common.go
+++ b/google_guest_agent/network/manager/common.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/osinfo"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
 	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/GoogleCloudPlatform/guest-agent/utils"
@@ -271,4 +272,14 @@ func fileExists(filepath string) bool {
 		return false
 	}
 	return !s.IsDir()
+}
+
+// isUbuntu1804 checks if agent is running on Ubuntu 18.04. This is a helper
+// method to support some exceptions we have for 18.04.
+func isUbuntu1804() bool {
+	info := osinfo.Get()
+	if info.OS == "ubuntu" && info.VersionID == "18.04" {
+		return true
+	}
+	return false
 }

--- a/google_guest_agent/network/manager/dhclient_linux.go
+++ b/google_guest_agent/network/manager/dhclient_linux.go
@@ -415,6 +415,12 @@ func partitionInterfaces(ctx context.Context, interfaces, ipv6Interfaces []strin
 			logger.Debugf("ManagePrimaryNIC is disabled, skipping dhclient launch for %s", iface)
 			continue
 		}
+		// On 18.04 we fallback to dhclient as networkctl is very old and has not reload support for example.
+		// Default netplan config will take care of it, do not launch dhclient for primary NIC on 18.04.
+		if (i == 0) && isUbuntu1804() {
+			logger.Debugf("ManagePrimaryNIC is enabled, but skipping primary nic as its managed by default OS config")
+			continue
+		}
 
 		// Check for IPv4 interfaces for which to obtain a lease.
 		processExists, err := dhclientProcessExists(ctx, iface, ipv4)

--- a/google_guest_agent/network/manager/netplan_linux.go
+++ b/google_guest_agent/network/manager/netplan_linux.go
@@ -177,6 +177,11 @@ func (n *netplan) Configure(ctx context.Context, config *cfg.Sections) {
 
 // IsManaging checks whether netplan is present in the system.
 func (n *netplan) IsManaging(ctx context.Context, iface string) (bool, error) {
+	if isUbuntu1804() {
+		logger.Infof("Running on Ubuntu 18.04, skipping use of netplan, falling back to dhclient")
+		return false, nil
+	}
+
 	// Check if the netplan CLI exists.
 	return cliExists("netplan")
 }

--- a/google_guest_agent/network/manager/wicked_linux.go
+++ b/google_guest_agent/network/manager/wicked_linux.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -223,12 +223,9 @@ func (n *wicked) writeEthernetConfigs(ifaces []string) error {
 		ifcfg := n.ifcfgFilePath(iface)
 
 		// Avoid writing the configuration file if the configuration already exists.
-		if _, err := os.Stat(ifcfg); err != nil {
-			if os.IsNotExist(err) {
-				logger.Debugf("%s already exists, skipping", ifcfg)
-				continue
-			}
-			return fmt.Errorf("error getting config file %s: %v", ifcfg, err)
+		if fileExists(ifcfg) {
+			logger.Infof("Wicked config %q already exists, will skip writing", ifcfg)
+			continue
 		}
 
 		contents := []string{
@@ -251,7 +248,7 @@ func (n *wicked) writeEthernetConfigs(ifaces []string) error {
 
 // ifcfgFilePath gets the file path for the configuration file for the given interface.
 func (n *wicked) ifcfgFilePath(iface string) string {
-	return path.Join(n.configDir, fmt.Sprintf("ifcfg-%s", iface))
+	return filepath.Join(n.configDir, fmt.Sprintf("ifcfg-%s", iface))
 }
 
 func (n *wicked) removeInterface(ctx context.Context, iface string) error {

--- a/google_guest_agent/network/manager/wicked_linux_test.go
+++ b/google_guest_agent/network/manager/wicked_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/cfg"
 	"github.com/GoogleCloudPlatform/guest-agent/google_guest_agent/run"
 )
 
@@ -238,6 +239,10 @@ func TestIsManaging(t *testing.T) {
 // TestWriteEthernetConfigs tests whether the wicked configuration files are
 // written correctly and to the right location.
 func TestWriteEthernetConfigs(t *testing.T) {
+	if err := cfg.Load(nil); err != nil {
+		t.Errorf("cfg.Load(nil) failed unexpectedly with error: %v", err)
+	}
+
 	tests := []struct {
 		// name is the name of the test.
 		name string


### PR DESCRIPTION
SUSE has a [upstream patch](https://build.opensuse.org/projects/openSUSE:Factory/packages/google-guest-agent/files/dont_overwrite_ifcfg.patch?expand=1&rev=943a4472cd121f20f0184b09a72a655d) to not overwrite default existing configs, incorporate it correctly in guest-agent to make sure it behaves as expected. 

Ubuntu 18.04 has unsupported version of `networkctl` fallback to `dhclient` as before and keep the behavior same.

/cc @dorileo @drewhli 

/hold