### PR TITLE
rpm packaging: fix plugin manager assumptions

### DIFF
--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -167,9 +167,17 @@ if [ $1 -eq 1 ]; then
 else
   # Package upgrade
   if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
     systemctl try-restart google-guest-agent.service >/dev/null 2>&1 || :
     %if 0%{?build_plugin_manager}
-      systemctl try-restart google-guest-agent-manager.service >/dev/null 2>&1 || :
+      systemctl enable google-guest-agent-manager.service >/dev/null 2>&1 || :
+      systemctl is-active google-guest-agent-manager.service >/dev/null 2>&1 || :
+      # If the unit is active do a try-restart, otherwise start it.
+      if [ $? -eq 0 ]; then
+        systemctl try-restart google-guest-agent-manager.service >/dev/null 2>&1 || :
+      else
+        systemctl start google-guest-agent-manager.service >/dev/null 2>&1 || :
+      if
     %endif
   fi
 fi


### PR DESCRIPTION
The assumption for guest-agent service is slightly different to plugin manager as its systemd unit may not be present - contrary to guest-agent that's assumed to always be present (given its longer history).