### PR TITLE
Add GOPATH to PATH in debian build

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,7 @@ Maintainer: Google Cloud Team <gc-team@google.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9.20160709), dh-golang (>= 1.1), golang-go, protobuf-compiler
+Build-Depends: debhelper (>= 9.20160709), dh-golang (>= 1.1), golang-go
 
 Package: google-guest-agent
 Architecture: any

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export PATH := /tmp/go/bin:$(PATH)
+export PATH := /tmp/go/bin:/usr/share/gocode/bin:$(PATH)
 export SHELL := env PATH=$(PATH) /bin/bash
 
 export DH_OPTIONS

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export PATH := /tmp/go/bin:/usr/share/gocode/bin:$(PATH)
+export PATH := /tmp/go/bin:/usr/share/gocode/bin:$(HOME)/.local/bin:$(PATH)
 export SHELL := env PATH=$(PATH) /bin/bash
 
 export DH_OPTIONS


### PR DESCRIPTION
This should resolve the current issue where it cannot find `protoc-gen-go` and `protoc-gen-go-grpc` during the build process. This also addresses a `protoc` issue where it could not find or resolve the import dependencies of `proto` files.