### PR TITLE
Implement support for vlan dynamic removal, update dhclient to remove only if configured

### DIFF
--- a/google_guest_agent/network/manager/common.go
+++ b/google_guest_agent/network/manager/common.go
@@ -264,16 +264,6 @@ func readYamlFile(filepath string, ptr any) error {
 	return yaml.Unmarshal(bytes, ptr)
 }
 
-// fileExists returns true only if file exists and it can successfully run stat
-// on the path.
-func fileExists(filepath string) bool {
-	s, err := os.Stat(filepath)
-	if err != nil && !errors.Is(os.ErrNotExist, err) {
-		return false
-	}
-	return !s.IsDir()
-}
-
 // isUbuntu1804 checks if agent is running on Ubuntu 18.04. This is a helper
 // method to support some exceptions we have for 18.04.
 func isUbuntu1804() bool {

--- a/google_guest_agent/network/manager/common_test.go
+++ b/google_guest_agent/network/manager/common_test.go
@@ -16,8 +16,6 @@ package manager
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"testing"
 
@@ -134,45 +132,6 @@ func TestVlanInterfaceParentMap(t *testing.T) {
 			}
 			if diff := cmp.Diff(test.wantMap, got); diff != "" {
 				t.Errorf("vlanInterfaceParentMap(%+v, %v) returned unexpected diff (-want,+got)\n%s", test.nics, test.allEthernetInterfaces, diff)
-			}
-		})
-	}
-}
-
-func TestFileExists(t *testing.T) {
-	dir := t.TempDir()
-	f, err := os.CreateTemp(dir, "file")
-	if err != nil {
-		t.Fatalf("os.CreateTemp(%s, file) failed unexpectedly with error: %v", dir, err)
-	}
-	defer f.Close()
-
-	tests := []struct {
-		name string
-		want bool
-		path string
-	}{
-		{
-			name: "existing_file",
-			want: true,
-			path: f.Name(),
-		},
-		{
-			name: "existing_dir",
-			want: false,
-			path: dir,
-		},
-		{
-			name: "non_existing_file",
-			want: false,
-			path: filepath.Join(t.TempDir(), "random"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := fileExists(test.path); got != test.want {
-				t.Errorf("fileExists(%s) = %t, want = %t", test.path, got, test.want)
 			}
 		})
 	}

--- a/google_guest_agent/network/manager/wicked_linux.go
+++ b/google_guest_agent/network/manager/wicked_linux.go
@@ -223,7 +223,7 @@ func (n *wicked) writeEthernetConfigs(ifaces []string) error {
 		ifcfg := n.ifcfgFilePath(iface)
 
 		// Avoid writing the configuration file if the configuration already exists.
-		if fileExists(ifcfg) {
+		if utils.FileExists(ifcfg, utils.TypeFile) {
 			logger.Infof("Wicked config %q already exists, will skip writing", ifcfg)
 			continue
 		}

--- a/utils/file.go
+++ b/utils/file.go
@@ -23,6 +23,16 @@ import (
 	"path/filepath"
 )
 
+// Type is the type of file.
+type Type int
+
+const (
+	// TypeDir is the type of directory.
+	TypeDir Type = iota
+	// TypeFile is the type of file.
+	TypeFile
+)
+
 // SaferWriteFile writes to a temporary file and then replaces the expected output file.
 // This prevents other processes from reading partial content while the writer is still writing.
 func SaferWriteFile(content []byte, outputFile string, perm fs.FileMode) error {
@@ -77,4 +87,22 @@ func WriteFile(content []byte, outputFile string, perm fs.FileMode) error {
 		return fmt.Errorf("unable to create required directories for %q: %w", outputFile, err)
 	}
 	return os.WriteFile(outputFile, content, perm)
+}
+
+// FileExists returns true if the file exists and match ftype.
+func FileExists(fpath string, ftype Type) bool {
+	stat, err := os.Stat(fpath)
+	if err != nil {
+		return false
+	}
+
+	if ftype == TypeDir && stat.IsDir() {
+		return true
+	}
+
+	if ftype == TypeFile && !stat.IsDir() {
+		return true
+	}
+
+	return false
 }

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -85,3 +85,64 @@ func TestCopyFileError(t *testing.T) {
 		t.Errorf("CopyFile(%s, %s) succeeded for non-existent file, want error", src, dst)
 	}
 }
+
+func TestFileExists(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "file")
+	if err != nil {
+		t.Fatalf("os.CreateTemp(%s, file) failed unexpectedly with error: %v", dir, err)
+	}
+	defer f.Close()
+
+	tests := []struct {
+		name  string
+		want  bool
+		fType Type
+		path  string
+	}{
+		{
+			name:  "existing_file",
+			want:  true,
+			fType: TypeFile,
+			path:  f.Name(),
+		},
+		{
+			name:  "exists_file_want_dir",
+			want:  false,
+			fType: TypeDir,
+			path:  f.Name(),
+		},
+		{
+			name:  "existing_dir",
+			want:  true,
+			fType: TypeDir,
+			path:  dir,
+		},
+		{
+			name:  "exists_dir_want_file",
+			want:  false,
+			fType: TypeFile,
+			path:  dir,
+		},
+		{
+			name:  "non_existing_file",
+			want:  false,
+			fType: TypeFile,
+			path:  filepath.Join(t.TempDir(), "random"),
+		},
+		{
+			name:  "non_existing_dir",
+			want:  false,
+			fType: TypeDir,
+			path:  filepath.Join(t.TempDir(), "random"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := FileExists(test.path, test.fType); got != test.want {
+				t.Errorf("FileExists(%s, %d) = %t, want = %t", test.path, test.fType, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 - Implements dynamic vlan removal for netplan/networkd manager.
 - Introduces util function to check if file/directory exists.
 - Updates dhclient rollback step to verify if it is dhclient managed before attempting rollback. Without this change dhclient rollback might remove configurations managed by netplan as dhclient still exists on debian-12.


/cc @dorileo @drewhli 

/hold