### PR TITLE
network: fix nmcli check pattern

### DIFF
--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -143,8 +143,8 @@ func (n *networkManager) IsManaging(ctx context.Context, iface string) (bool, er
 
 	// Check for existence of nmcli. Without nmcli, the agent cannot tell NetworkManager
 	// to reload the configs for its connections.
-	_, err := cliExists("nmcli")
-	if err != nil {
+	exists, err := cliExists("nmcli")
+	if !exists {
 		return false, err
 	}
 


### PR DESCRIPTION
Given the implementation of cliExists() we are ignoring one case by not checking the boolean return, if should assume nmcli doesn't exist if the boolean return is false and not the error as nil.