### PR TITLE
stable/network: fix cliExists() call pattern

### DIFF
--- a/google_guest_agent/network/manager/network_manager_linux.go
+++ b/google_guest_agent/network/manager/network_manager_linux.go
@@ -143,8 +143,8 @@ func (n *networkManager) IsManaging(ctx context.Context, iface string) (bool, er
 
 	// Check for existence of nmcli. Without nmcli, the agent cannot tell NetworkManager
 	// to reload the configs for its connections.
-	_, err := cliExists("nmcli")
-	if err != nil {
+	exists, err := cliExists("nmcli")
+	if !exists {
 		return false, err
 	}
 

--- a/google_guest_agent/network/manager/systemd_networkd_linux.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux.go
@@ -186,8 +186,8 @@ func (n *systemdNetworkd) Configure(ctx context.Context, config *cfg.Sections) {
 // to check if systemd-networkd is managing or has configured the provided interface.
 func (n *systemdNetworkd) IsManaging(ctx context.Context, iface string) (bool, error) {
 	// Check the version.
-	_, err := cliExists("networkctl")
-	if err != nil {
+	exists, err := cliExists("networkctl")
+	if !exists {
 		return false, err
 	}
 


### PR DESCRIPTION
In networkd and NetworkManager implementation we were wrongly assuming the existing of the cli based only the error return, with that we were ignoring one of the conditions where we don't return an error even though the cli doesn't exists.