### PR TITLE
Introduce new format for ethernet interfaces

### DIFF
--- a/google_guest_agent/network/manager/common_test.go
+++ b/google_guest_agent/network/manager/common_test.go
@@ -15,68 +15,12 @@
 package manager
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/guest-agent/metadata"
 	"github.com/google/go-cmp/cmp"
 )
-
-func TestVlanParentInterfaceSuccess(t *testing.T) {
-	tests := []struct {
-		parentInterface string
-		expectedResult  string
-	}{
-		{"/computeMetadata/v1/instance/network-interfaces/0/", "eth0"},
-		{"/computeMetadata/v1/instance/network-interfaces/1/", "eth1"},
-		{"/computeMetadata/v1/instance/network-interfaces/2/", "eth2"},
-	}
-
-	availableNics := []string{
-		"eth0",
-		"eth1",
-		"eth2",
-	}
-
-	for i, curr := range tests {
-		t.Run(fmt.Sprintf("test-vlan-parent-success-%d", i), func(t *testing.T) {
-			vlan := metadata.VlanInterface{ParentInterface: curr.parentInterface}
-
-			parent, err := vlanParentInterface(availableNics, vlan)
-			if err != nil {
-				t.Fatalf("expected err: nil, got: %+v", err)
-			}
-
-			if parent != curr.expectedResult {
-				t.Fatalf("got wront parent value, expected: %s, got: %s", curr.expectedResult, parent)
-			}
-		})
-	}
-}
-
-func TestVlanParentInterfaceFailure(t *testing.T) {
-	tests := []string{
-		"/computeMetadata/v1/instance/network-interfaces/x/",
-		"/computeMetadata/v1/instance/network-interfaces/0/",                    // Valid format but interfaces slices will have zero elements.
-		"/computeMetadata/v1/instance/network-interfaces/18446744073709551616/", // Out of int64 range - strconv.Atoi() should fail.
-		"/computeMetadata/v1/instance/0/",
-		"/computeMetadata/v1/instance/network-interfaces0/",
-		"/computeMetadata/v1/instance/network-interfaces/",
-		"/computeMetadata/",
-		"",
-	}
-
-	for i, curr := range tests {
-		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
-			vlan := metadata.VlanInterface{ParentInterface: curr}
-			_, err := vlanParentInterface([]string{}, vlan)
-			if err == nil {
-				t.Fatalf("vlanParentInterface(%s) = nil, want: non-nil", curr)
-			}
-		})
-	}
-}
 
 func TestVlanInterfaceListsIpv6(t *testing.T) {
 	nics := map[int]VlanInterface{
@@ -91,48 +35,5 @@ func TestVlanInterfaceListsIpv6(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("vlanInterfaceListsIpv6(%+v) returned unexpected diff (-want,+got)\n%s", nics, diff)
-	}
-}
-
-func TestVlanInterfaceParentMap(t *testing.T) {
-	tests := []struct {
-		name                  string
-		nics                  map[int]metadata.VlanInterface
-		allEthernetInterfaces []string
-		wantErr               bool
-		wantMap               map[int]string
-	}{
-		{
-			name:                  "all_valid_nics",
-			allEthernetInterfaces: []string{"ens3", "ens4"},
-			nics: map[int]metadata.VlanInterface{
-				4: {Vlan: 4, ParentInterface: "/computeMetadata/v1/instance/network-interfaces/0/"},
-				5: {Vlan: 5, ParentInterface: "/computeMetadata/v1/instance/network-interfaces/1/"},
-			},
-			wantMap: map[int]string{
-				4: "ens3",
-				5: "ens4",
-			},
-		},
-		{
-			name:                  "invalid_parent",
-			allEthernetInterfaces: []string{"ens3"},
-			nics: map[int]metadata.VlanInterface{
-				5: {Vlan: 5, ParentInterface: "/computeMetadata/v1/instance/network-interfaces/1/"},
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := vlanInterfaceParentMap(test.nics, test.allEthernetInterfaces)
-			if (err != nil) != test.wantErr {
-				t.Fatalf("vlanInterfaceParentMap(%+v, %v) = error [%v], want error: %t", test.nics, test.allEthernetInterfaces, err, test.wantErr)
-			}
-			if diff := cmp.Diff(test.wantMap, got); diff != "" {
-				t.Errorf("vlanInterfaceParentMap(%+v, %v) returned unexpected diff (-want,+got)\n%s", test.nics, test.allEthernetInterfaces, diff)
-			}
-		})
 	}
 }

--- a/google_guest_agent/network/manager/network_manager_linux_test.go
+++ b/google_guest_agent/network/manager/network_manager_linux_test.go
@@ -387,8 +387,9 @@ func TestWriteNetworkManagerConfigs(t *testing.T) {
 				t.Fatalf("error creating temp dir: %v", err)
 			}
 			testNetworkManager.configDir = configDir
+			testEthernetInterfaces := createInterfaces(test.testInterfaces)
 
-			conns, err := testNetworkManager.writeNetworkManagerConfigs(test.testInterfaces)
+			conns, err := testNetworkManager.writeNetworkManagerConfigs(testEthernetInterfaces)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -443,8 +444,8 @@ func TestVlanInterface(t *testing.T) {
 	interfaceName := ifaces[1].Name
 
 	validNics := &Interfaces{
-		EthernetInterfaces: []metadata.NetworkInterfaces{{
-			Mac: ifaces[1].HardwareAddr.String(),
+		EthernetInterfaces: []EthernetInterface{{
+			NetworkInterfaces: metadata.NetworkInterfaces{Mac: ifaces[1].HardwareAddr.String()},
 		}},
 		VlanInterfaces: map[int]VlanInterface{
 			22: {

--- a/google_guest_agent/network/manager/wicked_linux_test.go
+++ b/google_guest_agent/network/manager/wicked_linux_test.go
@@ -275,8 +275,9 @@ func TestWriteEthernetConfigs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			wickedTestSetup(t, wickedTestOpts{})
+			testEthernetInterfaces := createInterfaces(test.testInterfaces)
 
-			err := mockWicked.writeEthernetConfigs(test.testInterfaces)
+			err := mockWicked.writeEthernetConfigs(testEthernetInterfaces)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
- Allow for fidelity with interface indices even when some are invalid
- Skip interfaces that are invalid instead of completely erroring network setup
- Complete refactor to use the new EthernetInterface struct

I've also introduced some new test methods within `common.go` to make test setup easier, and removed some methods that aren't used anywhere (like `vlanParentInterface`)

/cc @ChaitanyaKulkarni28 @dorileo 