### PR TITLE
Fix Debian packaging if guest agent manager is not checked out

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -22,7 +22,7 @@ override_dh_auto_install:
 	install -p -m 0644 instance_configs.cfg debian/google-guest-agent/usr/share/google-guest-agent
 	install -d debian/google-guest-agent/lib/systemd/system
 	install -p -m 0644 gce-workload-cert-refresh.timer debian/google-guest-agent/lib/systemd/system/
-	if [[ -d google-guest-agent ]]; then\
+	if [ -d google-guest-agent ]; then\
 		install -p -m 0644 google-guest-agent/cmd/google_guest_agent/google_guest_agent debian/google-guest-agent/usr/bin/google_guest_agent_manager;\
 	fi
 
@@ -31,7 +31,7 @@ override_dh_golang:
 
 override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
-	if [[ -d google-guest-agent ]]; then\
+	if [ -d google-guest-agent ]; then\
 		VERSION=$(VERSION) make -C google-guest-agent cmd/google_guest_agent/google_guest_agent;\
 	fi
 
@@ -42,13 +42,13 @@ override_dh_systemd_enable:
 	install -d debian/google-guest-agent/lib/systemd/system
 	install -p -m 0644 *.service debian/google-guest-agent/lib/systemd/system/
 	# Don't include guest agent manager if not building with it.
-	if [[ ! -d google-guest-agent ]]; then\
-		rm -f debian/google-guest-agent/lib/systemd/systemd/google-guest-agent-manager.service;\
+	if [ ! -d google-guest-agent ]; then\
+		rm -f debian/google-guest-agent/lib/systemd/system/google-guest-agent-manager.service;\
 	fi
 	install -d debian/google-guest-agent/lib/systemd/system-preset
 	install -p -m 0644 *.preset debian/google-guest-agent/lib/systemd/system-preset/
 	dh_systemd_enable google-guest-agent.service google-startup-scripts.service google-shutdown-scripts.service gce-workload-cert-refresh.timer
-	if [[ -d google-guest-agent ]]; then\
+	if [ -d google-guest-agent ]; then\
 		dh_systemd_enable google-guest-agent-manager.service;\
 	fi
 
@@ -56,6 +56,6 @@ override_dh_systemd_start:
 	# Only perform start/stop actions for the guest agent and cert refresh timer.
 	dh_systemd_start google-guest-agent.service
 	dh_systemd_start gce-workload-cert-refresh.timer
-	if [[ -d google-guest-agent ]]; then\
+	if [ -d google-guest-agent ]; then\
 		dh_systemd_start google-guest-agent-manager.service;\
 	fi


### PR DESCRIPTION
This PR fixes Debian packing if no Google Guest Agent Manager code has been checked out from [`google-guest-agent`](https://github.com/GoogleCloudPlatform/google-guest-agent). The previous code had a typo to remove its unit file.