### PR TITLE
vlan: don't index based on the vlan ID

### DIFF
--- a/google_guest_agent/network/manager/common.go
+++ b/google_guest_agent/network/manager/common.go
@@ -108,18 +108,6 @@ func vlanInterfaceParentMap(nics map[int]metadata.VlanInterface, allEthernetInte
 	return vlans, nil
 }
 
-// vlanInterfaceListsIpv6 gets a list of VLAN IDs that support IPv6.
-func vlanInterfaceListsIpv6(nics map[int]VlanInterface) []int {
-	var googleIpv6Interfaces []int
-
-	for _, ni := range nics {
-		if ni.DHCPv6Refresh != "" {
-			googleIpv6Interfaces = append(googleIpv6Interfaces, ni.Vlan)
-		}
-	}
-	return googleIpv6Interfaces
-}
-
 // interfaceListsIpv4Ipv6 gets a list of interface names. The first list is a list of all
 // interfaces, and the second list consists of only interfaces that support IPv6.
 func interfaceListsIpv4Ipv6(nics []metadata.NetworkInterfaces) ([]string, []string) {

--- a/google_guest_agent/network/manager/common_test.go
+++ b/google_guest_agent/network/manager/common_test.go
@@ -16,7 +16,6 @@ package manager
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/guest-agent/metadata"
@@ -75,22 +74,6 @@ func TestVlanParentInterfaceFailure(t *testing.T) {
 				t.Fatalf("vlanParentInterface(%s) = nil, want: non-nil", curr)
 			}
 		})
-	}
-}
-
-func TestVlanInterfaceListsIpv6(t *testing.T) {
-	nics := map[int]VlanInterface{
-		0: {VlanInterface: metadata.VlanInterface{Vlan: 4, DHCPv6Refresh: "123456"}},
-		1: {VlanInterface: metadata.VlanInterface{Vlan: 5}},
-		2: {VlanInterface: metadata.VlanInterface{Vlan: 6, MTU: 1234}},
-		3: {VlanInterface: metadata.VlanInterface{Vlan: 7, Mac: "acd", ParentInterface: "/parent/0", DHCPv6Refresh: "7890"}},
-	}
-	want := []int{4, 7}
-	got := vlanInterfaceListsIpv6(nics)
-	sort.Ints(got)
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("vlanInterfaceListsIpv6(%+v) returned unexpected diff (-want,+got)\n%s", nics, diff)
 	}
 }
 

--- a/google_guest_agent/network/manager/dhclient_linux_test.go
+++ b/google_guest_agent/network/manager/dhclient_linux_test.go
@@ -49,7 +49,7 @@ func (d dhclientMockRunner) Quiet(ctx context.Context, name string, args ...stri
 		for _, arg := range args {
 			msg += fmt.Sprintf(" %v", arg)
 		}
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 	return nil
 }

--- a/google_guest_agent/network/manager/manager.go
+++ b/google_guest_agent/network/manager/manager.go
@@ -83,7 +83,7 @@ type Interfaces struct {
 	EthernetInterfaces []metadata.NetworkInterfaces
 
 	// VlanInterfaces are the vLAN interfaces descriptors offered by metadata.
-	VlanInterfaces map[int]VlanInterface
+	VlanInterfaces map[string]VlanInterface
 }
 
 // guestAgentSection is the section added to guest-agent-written ini files to indicate
@@ -163,7 +163,8 @@ func reformatVlanNics(mds *metadata.Descriptor, nics *Interfaces, ethernetInterf
 		}
 
 		for vlanID, vlan := range vlans {
-			nics.VlanInterfaces[vlanID] = VlanInterface{VlanInterface: vlan, ParentInterfaceID: ethernetInterfaces[parentID]}
+			mapID := fmt.Sprintf("%d-%d", parentID, vlanID)
+			nics.VlanInterfaces[mapID] = VlanInterface{VlanInterface: vlan, ParentInterfaceID: ethernetInterfaces[parentID]}
 		}
 	}
 	return nil
@@ -191,7 +192,7 @@ func SetupInterfaces(ctx context.Context, config *cfg.Sections, mds *metadata.De
 
 	nics := &Interfaces{
 		EthernetInterfaces: mds.Instance.NetworkInterfaces,
-		VlanInterfaces:     map[int]VlanInterface{},
+		VlanInterfaces:     map[string]VlanInterface{},
 	}
 
 	interfaces, err := interfaceNames(nics.EthernetInterfaces)
@@ -335,7 +336,7 @@ func FallbackToDefault(ctx context.Context) error {
 func buildInterfacesFromAllPhysicalNICs() (*Interfaces, error) {
 	nics := &Interfaces{
 		EthernetInterfaces: nil,
-		VlanInterfaces:     map[int]VlanInterface{},
+		VlanInterfaces:     map[string]VlanInterface{},
 	}
 
 	interfaces, err := net.Interfaces()

--- a/google_guest_agent/network/manager/manager_test.go
+++ b/google_guest_agent/network/manager/manager_test.go
@@ -335,11 +335,11 @@ func TestReformatVlanNics(t *testing.T) {
 			},
 		},
 	}}
-	nics := &Interfaces{VlanInterfaces: map[int]VlanInterface{}}
-	want := &Interfaces{VlanInterfaces: map[int]VlanInterface{
-		5: {VlanInterface: metadata.VlanInterface{Mac: "a", ParentInterface: "/computeMetadata/v1/instance/network-interfaces/0/", Vlan: 5}, ParentInterfaceID: "eth0"},
-		6: {VlanInterface: metadata.VlanInterface{Mac: "b", Vlan: 6, IP: "1.2.3.4"}, ParentInterfaceID: "eth0"},
-		7: {VlanInterface: metadata.VlanInterface{Mac: "c", Vlan: 7, DHCPv6Refresh: "123456"}, ParentInterfaceID: "eth1"},
+	nics := &Interfaces{VlanInterfaces: map[string]VlanInterface{}}
+	want := &Interfaces{VlanInterfaces: map[string]VlanInterface{
+		"0-5": {VlanInterface: metadata.VlanInterface{Mac: "a", ParentInterface: "/computeMetadata/v1/instance/network-interfaces/0/", Vlan: 5}, ParentInterfaceID: "eth0"},
+		"0-6": {VlanInterface: metadata.VlanInterface{Mac: "b", Vlan: 6, IP: "1.2.3.4"}, ParentInterfaceID: "eth0"},
+		"1-7": {VlanInterface: metadata.VlanInterface{Mac: "c", Vlan: 7, DHCPv6Refresh: "123456"}, ParentInterfaceID: "eth1"},
 	}}
 
 	ethernetInterfaces := []string{"eth0", "eth1"}
@@ -365,7 +365,7 @@ func TestReformatVlanNicsError(t *testing.T) {
 			},
 		},
 	}}
-	nics := &Interfaces{VlanInterfaces: map[int]VlanInterface{}}
+	nics := &Interfaces{VlanInterfaces: map[string]VlanInterface{}}
 
 	tests := []struct {
 		name               string

--- a/google_guest_agent/network/manager/netplan_linux_test.go
+++ b/google_guest_agent/network/manager/netplan_linux_test.go
@@ -193,8 +193,8 @@ func TestSetupVlanInterface(t *testing.T) {
 				Mac: ifaces[1].HardwareAddr.String(),
 			},
 		},
-		VlanInterfaces: map[int]VlanInterface{
-			5: {
+		VlanInterfaces: map[string]VlanInterface{
+			"0-5": {
 				VlanInterface: metadata.VlanInterface{
 					Mac:  "mac-address",
 					Vlan: 5,
@@ -202,7 +202,7 @@ func TestSetupVlanInterface(t *testing.T) {
 				},
 				ParentInterfaceID: ifaces[1].Name,
 			},
-			6: {
+			"0-6": {
 				VlanInterface: metadata.VlanInterface{
 					Mac:           "mac-address2",
 					Vlan:          6,
@@ -426,8 +426,8 @@ func TestPartialVlanRemoval(t *testing.T) {
 	}
 
 	nics := &Interfaces{
-		VlanInterfaces: map[int]VlanInterface{
-			5: {
+		VlanInterfaces: map[string]VlanInterface{
+			"ens4-5": {
 				VlanInterface: metadata.VlanInterface{
 					Mac:  "mac-address",
 					Vlan: 5,
@@ -439,8 +439,11 @@ func TestPartialVlanRemoval(t *testing.T) {
 	}
 
 	wantNics := &Interfaces{
-		VlanInterfaces: map[int]VlanInterface{
-			6: {
+		VlanInterfaces: map[string]VlanInterface{
+			"ens4-6": {
+				VlanInterface: metadata.VlanInterface{
+					Vlan: 6,
+				},
 				ParentInterfaceID: "ens4",
 			},
 		},
@@ -449,6 +452,10 @@ func TestPartialVlanRemoval(t *testing.T) {
 	got, err := netplan.findVlanDiff(nics)
 	if err != nil {
 		t.Fatalf("netplan.findVlanDiff(%+v) failed unexpectedly with error: %v", nics, err)
+	}
+
+	if got == nil {
+		t.Fatalf("netplan.findVlanDiff(%+v) return nil, expected non nil", nics)
 	}
 
 	if diff := cmp.Diff(wantNics, got); diff != "" {

--- a/google_guest_agent/network/manager/network_manager_linux_test.go
+++ b/google_guest_agent/network/manager/network_manager_linux_test.go
@@ -446,8 +446,8 @@ func TestVlanInterface(t *testing.T) {
 		EthernetInterfaces: []metadata.NetworkInterfaces{{
 			Mac: ifaces[1].HardwareAddr.String(),
 		}},
-		VlanInterfaces: map[int]VlanInterface{
-			22: {
+		VlanInterfaces: map[string]VlanInterface{
+			"0-22": {
 				VlanInterface: metadata.VlanInterface{
 					Mac:             "foobar",
 					ParentInterface: "/computeMetadata/v1/instance/network-interfaces/0/",

--- a/google_guest_agent/network/manager/systemd_networkd_linux_test.go
+++ b/google_guest_agent/network/manager/systemd_networkd_linux_test.go
@@ -647,10 +647,11 @@ func TestSetupVlanInterfaceSuccess(t *testing.T) {
 				dhclientTestTearDown(t)
 			})
 
+			mapIdx := fmt.Sprintf("%s-%d", curr.parentID, curr.vlanInterface.Vlan)
 			nics := &Interfaces{
 				EthernetInterfaces: []metadata.NetworkInterfaces{curr.ethernetInterface},
-				VlanInterfaces: map[int]VlanInterface{
-					curr.vlanInterface.Vlan: {VlanInterface: curr.vlanInterface, ParentInterfaceID: curr.parentID},
+				VlanInterfaces: map[string]VlanInterface{
+					mapIdx: {VlanInterface: curr.vlanInterface, ParentInterfaceID: curr.parentID},
 				},
 			}
 


### PR DESCRIPTION
The vlan ID may be repeated in a system as long as the vlan is set for different parent interfaces. This change makes sure to map based on the combination of parentID + Vlan (in the form of parentID-Vlan).