### PR TITLE
Fix windows package build failures

### DIFF
--- a/packaging/googet/windows_agent_build.sh
+++ b/packaging/googet/windows_agent_build.sh
@@ -39,5 +39,5 @@ fi
 BUILD_DIR=$(pwd)
 pushd $GUEST_AGENT_REPO
 GOOS=windows VERSION=$version make cmd/google_guest_agent/google_guest_agent
-cp cmd/google_guest_agent/google_guest_agent.exe $BUILD_DIR/GCEWindowsAgentManager.exe
+cp cmd/google_guest_agent/google_guest_agent $BUILD_DIR/GCEWindowsAgentManager.exe
 popd


### PR DESCRIPTION
Builds are failing with error - `google_metadata_script_runner[880]: startup-script-url: cp: cannot stat 'cmd/google_guest_agent/google_guest_agent.exe': No such file or directory`

/cc @dorileo @drewhli 

