### PR TITLE
Start bundling ggactl_plugin_cleanup binary in all agent packages

### DIFF
--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+if [ "$1" = "purge" -o "$1" = "remove" ] ; then
+    systemctl stop google-guest-agent-manager >/dev/null 2>&1 || :
+    ggactl_plugin_cleanup all >/dev/null 2>&1 || :
+fi
+
+#DEBHELPER#

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,6 +24,7 @@ override_dh_auto_install:
 	install -p -m 0644 gce-workload-cert-refresh.timer debian/google-guest-agent/lib/systemd/system/
 	if [ -d google-guest-agent ]; then\
 		install -p -m 0644 google-guest-agent/cmd/google_guest_agent/google_guest_agent debian/google-guest-agent/usr/bin/google_guest_agent_manager;\
+		install -p -m 0644 google-guest-agent/cmd/ggactl/ggactl_plugin_cleanup debian/google-guest-agent/usr/bin/ggactl_plugin_cleanup;\
 	fi
 
 override_dh_golang:
@@ -33,6 +34,7 @@ override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 	if [ -d google-guest-agent ]; then\
 		VERSION=$(VERSION) make -C google-guest-agent cmd/google_guest_agent/google_guest_agent;\
+		VERSION=$(VERSION) make -C google-guest-agent cmd/ggactl/ggactl_plugin_cleanup;\
 	fi
 
 override_dh_installinit:

--- a/packaging/googet/agent_uninstall.ps1
+++ b/packaging/googet/agent_uninstall.ps1
@@ -16,8 +16,11 @@ Stop-Service GCEAgent -Verbose
 & sc.exe delete GCEAgent
 
 $name = 'GCEAgentManager'
+$cleanup_exe = "C:\Program Files\Google\Compute Engine\agent\ggactl_plugin_cleanup.exe"
+
 if (Get-Service $name -ErrorAction SilentlyContinue) {
     Stop-Service $name -Verbose
+    & $cleanup_exe all
     & sc.exe delete $name
 }
 

--- a/packaging/googet/google-compute-engine-windows.goospec
+++ b/packaging/googet/google-compute-engine-windows.goospec
@@ -10,6 +10,7 @@
     "GCEWindowsAgentManager.exe": "<ProgramFiles>/Google/Compute Engine/agent/GCEWindowsAgentManager.exe",
     "GCEWindowsAgent.exe": "<ProgramFiles>/Google/Compute Engine/agent/GCEWindowsAgent.exe",
     "GCEAuthorizedKeysCommand.exe": "<ProgramFiles>/Google/Compute Engine/agent/GCEAuthorizedKeysCommand.exe",
+    "ggactl_plugin_cleanup.exe": "<ProgramFiles>/Google/Compute Engine/agent/ggactl_plugin_cleanup.exe",
     "THIRD_PARTY_LICENSES": "<ProgramFiles>/Google/Compute Engine/THIRD_PARTY_LICENSES/",
     "LICENSE": "<ProgramFiles>/Google/Compute Engine/agent/LICENSE.txt"
   },
@@ -36,6 +37,7 @@
   ],
   "sources": [{
       "include": [
+        "ggactl_plugin_cleanup.exe",
         "GCEWindowsAgent.exe",
         "GCEWindowsAgentManager.exe",
 	"GCEAuthorizedKeysCommand.exe",

--- a/packaging/googet/windows_agent_build.sh
+++ b/packaging/googet/windows_agent_build.sh
@@ -33,11 +33,14 @@ if [[ ! -f "$GUEST_AGENT_REPO/Makefile" ]]; then
     # This is a placeholder file for guest-agent package, google-compute-engine-windows.goospec
     # looks for this file during goopack packaging and will fail if not found.
     echo "This is a placeholder file so guest agent package build without error. Package will have actual Guest Agent Manager executable instead if both repos are cloned side-by-side." > GCEWindowsAgentManager.exe
+    echo "This is a placeholder file so guest agent package build without error. Package will have actual Guest Agent Manager executable instead if both repos are cloned side-by-side." > ggactl_plugin_cleanup.exe
     exit 0
 fi
 
 BUILD_DIR=$(pwd)
 pushd $GUEST_AGENT_REPO
 GOOS=windows VERSION=$version make cmd/google_guest_agent/google_guest_agent
+GOOS=windows VERSION=$version make cmd/ggactl/ggactl_plugin_cleanup
 cp cmd/google_guest_agent/google_guest_agent $BUILD_DIR/GCEWindowsAgentManager.exe
+cp cmd/ggactl/ggactl_plugin_cleanup $BUILD_DIR/ggactl_plugin_cleanup.exe
 popd

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -63,6 +63,7 @@ done
 %if 0%{?build_plugin_manager}
 pushd %{name}-extra-%{version}/
   VERSION=%{version} make cmd/google_guest_agent/google_guest_agent
+  VERSION=%{version} make cmd/ggactl/ggactl_plugin_cleanup
 popd
 %endif
 
@@ -80,6 +81,7 @@ install -p -m 0644 instance_configs.cfg %{buildroot}/usr/share/google-guest-agen
 # Compat agent, it will become google_guest_agent after the full package transition.
 %if 0%{?build_plugin_manager}
 install -p -m 0755 %{name}-extra-%{version}/cmd/google_guest_agent/google_guest_agent %{buildroot}%{_bindir}/google_guest_agent_manager
+install -p -m 0755 %{name}-extra-%{version}/cmd/ggactl/ggactl_plugin_cleanup %{buildroot}%{_bindir}/ggactl_plugin_cleanup
 %endif
 
 %if 0%{?el6}
@@ -111,6 +113,7 @@ install -p -m 0644 90-%{name}.preset %{buildroot}%{_presetdir}/90-%{name}.preset
 
 %if 0%{?build_plugin_manager}
 %{_bindir}/google_guest_agent_manager
+%{_bindir}/ggactl_plugin_cleanup
 %endif
 
 %{_bindir}/google_metadata_script_runner
@@ -190,6 +193,7 @@ if [ $1 -eq 0 ]; then
     systemctl stop google-guest-agent.service >/dev/null 2>&1 || :
     %if 0%{?build_plugin_manager}
       systemctl stop google-guest-agent-manager.service >/dev/null 2>&1 || :
+      ggactl_plugin_cleanup all >/dev/null 2>&1 || :
     %endif
   fi
 fi


### PR DESCRIPTION
- Bundles `ggactl_plugin_cleanup` binary for all apt/yum/goo packages
- Calls cleanup on package removal

/cc @dorileo @drewhli 

/hold 