### PR TITLE
vlan: toggle vlan configuration in debian packaging

### DIFF
--- a/instance_configs.cfg
+++ b/instance_configs.cfg
@@ -36,6 +36,7 @@ dhclient_script = /sbin/google-dhclient-script
 dhcp_command = 
 ip_forwarding = true
 setup = true
+vlan_setup_enabled = false
 
 [OSLogin]
 cert_authentication = true

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -19,6 +19,7 @@ override_dh_auto_install:
 	# Binary-only package.
 	dh_auto_install -- --no-source
 	install -d debian/google-guest-agent/usr/share/google-guest-agent
+	sed -i "s/vlan_setup_enabled = false/vlan_setup_enabled = true/g" instance_configs.cfg
 	install -p -m 0644 instance_configs.cfg debian/google-guest-agent/usr/share/google-guest-agent
 	install -d debian/google-guest-agent/lib/systemd/system
 	install -p -m 0644 gce-workload-cert-refresh.timer debian/google-guest-agent/lib/systemd/system/


### PR DESCRIPTION
We are enabling vlan support by default for debian systems. Note we are not forcing overwriting the configuration for updated instances, user will need to manually toggle the configuration for long running instances if they need/want to enable it.