### PR TITLE
Introduce compat-manager systemd unit

### DIFF
--- a/google-guest-compat-manager.service
+++ b/google-guest-compat-manager.service
@@ -1,12 +1,11 @@
 [Unit]
-Description=Google Compute Engine Guest Agent Plugin Manager
+Description=Google Compute Engine Guest Compat Manager
 After=network-online.target syslog.service
 After=network.service networking.service NetworkManager.service systemd-networkd.service
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/google_guest_agent_manager
-OOMScoreAdjust=-999
+ExecStart=/usr/bin/google_guest_compat_manager
 Restart=always
 
 [Install]


### PR DESCRIPTION
Guest Agent compat manager service should enable either core plugin or guest agent. Removed plugin manager dependency on guest agent as it maybe disabled based on setting and plugin manager service really just needs network to be up before it starts.

Note: This is not packaged yet and will be part of future feature release.

/cc @dorileo @drewhli 