### PR TITLE
Include core plugin binary for all packages

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,9 +24,11 @@ override_dh_auto_install:
 	install -d debian/google-guest-agent/lib/systemd/system
 	install -p -m 0644 gce-workload-cert-refresh.timer debian/google-guest-agent/lib/systemd/system/
 	if [ -d google-guest-agent ]; then\
-		install -p -m 0644 google-guest-agent/cmd/google_guest_compat_manager/google_guest_compat_manager debian/google-guest-agent/usr/bin/google_guest_compat_manager;\
-		install -p -m 0644 google-guest-agent/cmd/google_guest_agent/google_guest_agent debian/google-guest-agent/usr/bin/google_guest_agent_manager;\
-		install -p -m 0644 google-guest-agent/cmd/ggactl/ggactl_plugin_cleanup debian/google-guest-agent/usr/bin/ggactl_plugin_cleanup;\
+		install -d debian/google-guest-agent/usr/lib/google/guest-agent;\
+		install -p -m 0755 google-guest-agent/cmd/google_guest_compat_manager/google_guest_compat_manager debian/google-guest-agent/usr/bin/google_guest_compat_manager;\
+		install -p -m 0755 google-guest-agent/cmd/google_guest_agent/google_guest_agent debian/google-guest-agent/usr/bin/google_guest_agent_manager;\
+		install -p -m 0755 google-guest-agent/cmd/ggactl/ggactl_plugin_cleanup debian/google-guest-agent/usr/bin/ggactl_plugin_cleanup;\
+		install -p -m 0755 google-guest-agent/cmd/core_plugin/core_plugin debian/google-guest-agent/usr/lib/google/guest-agent/core_plugin;\
 	fi
 
 override_dh_golang:
@@ -38,6 +40,7 @@ override_dh_auto_build:
 		VERSION=$(VERSION) make -C google-guest-agent cmd/google_guest_compat_manager/google_guest_compat_manager;\
 		VERSION=$(VERSION) make -C google-guest-agent cmd/google_guest_agent/google_guest_agent;\
 		VERSION=$(VERSION) make -C google-guest-agent cmd/ggactl/ggactl_plugin_cleanup;\
+		VERSION=$(VERSION) make -C google-guest-agent cmd/core_plugin/core_plugin;\
 	fi
 
 override_dh_installinit:

--- a/packaging/googet/google-compute-engine-windows.goospec
+++ b/packaging/googet/google-compute-engine-windows.goospec
@@ -7,6 +7,7 @@
   "description": "Google Compute Engine Windows agent",
   "source": "https://github.com/GoogleCloudPlatform/guest-agent/",
   "files": {
+    "CorePlugin.exe": "<ProgramFiles>/Google/Compute Engine/agent/CorePlugin.exe",
     "GCEWindowsAgentManager.exe": "<ProgramFiles>/Google/Compute Engine/agent/GCEWindowsAgentManager.exe",
     "GCEWindowsCompatManager.exe": "<ProgramFiles>/Google/Compute Engine/agent/GCEWindowsCompatManager.exe",
     "GCEWindowsAgent.exe": "<ProgramFiles>/Google/Compute Engine/agent/GCEWindowsAgent.exe",
@@ -38,6 +39,7 @@
   ],
   "sources": [{
       "include": [
+        "CorePlugin.exe",
         "ggactl_plugin_cleanup.exe",
         "GCEWindowsAgent.exe",
         "GCEWindowsCompatManager.exe",

--- a/packaging/googet/windows_agent_build.sh
+++ b/packaging/googet/windows_agent_build.sh
@@ -35,6 +35,7 @@ if [[ ! -f "$GUEST_AGENT_REPO/Makefile" ]]; then
     echo "This is a placeholder file so guest agent package build without error. Package will have actual Guest Agent Manager executable instead if both repos are cloned side-by-side." > GCEWindowsAgentManager.exe
     echo "This is a placeholder file so guest agent package build without error. Package will have actual Guest Agent Manager executable instead if both repos are cloned side-by-side." > ggactl_plugin_cleanup.exe
     echo "This is a placeholder file so guest agent package build without error. Package will have actual Guest Agent Manager executable instead if both repos are cloned side-by-side." > GCEWindowsCompatManager.exe
+    echo "This is a placeholder file so guest agent package build without error. Package will have actual Guest Agent Manager executable instead if both repos are cloned side-by-side." > CorePlugin.exe
     exit 0
 fi
 
@@ -43,8 +44,10 @@ pushd $GUEST_AGENT_REPO
 GOOS=windows VERSION=$version make cmd/google_guest_agent/google_guest_agent
 GOOS=windows VERSION=$version make cmd/ggactl/ggactl_plugin_cleanup
 GOOS=windows VERSION=$version make cmd/google_guest_compat_manager/google_guest_compat_manager
+GOOS=windows VERSION=%{version} make cmd/core_plugin/core_plugin
 
 cp cmd/google_guest_agent/google_guest_agent $BUILD_DIR/GCEWindowsAgentManager.exe
 cp cmd/ggactl/ggactl_plugin_cleanup $BUILD_DIR/ggactl_plugin_cleanup.exe
 cp cmd/google_guest_compat_manager/google_guest_compat_manager $BUILD_DIR/GCEWindowsCompatManager.exe
+cp cmd/core_plugin/core_plugin $BUILD_DIR/CorePlugin.exe
 popd

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -65,6 +65,7 @@ pushd %{name}-extra-%{version}/
   VERSION=%{version} make cmd/google_guest_agent/google_guest_agent
   VERSION=%{version} make cmd/ggactl/ggactl_plugin_cleanup
   VERSION=%{version} make cmd/google_guest_compat_manager/google_guest_compat_manager
+  VERSION=%{version} make cmd/core_plugin/core_plugin
 popd
 %endif
 
@@ -81,9 +82,11 @@ install -p -m 0644 instance_configs.cfg %{buildroot}/usr/share/google-guest-agen
 
 # Compat agent, it will become google_guest_agent after the full package transition.
 %if 0%{?build_plugin_manager}
+install -d %{buildroot}%{_exec_prefix}/lib/google/guest_agent
 install -p -m 0755 %{name}-extra-%{version}/cmd/google_guest_agent/google_guest_agent %{buildroot}%{_bindir}/google_guest_agent_manager
 install -p -m 0755 %{name}-extra-%{version}/cmd/ggactl/ggactl_plugin_cleanup %{buildroot}%{_bindir}/ggactl_plugin_cleanup
 install -p -m 0755 %{name}-extra-%{version}/cmd/google_guest_compat_manager/google_guest_compat_manager %{buildroot}%{_bindir}/google_guest_compat_manager
+install -p -m 0755 %{name}-extra-%{version}/cmd/core_plugin/core_plugin %{buildroot}%{_exec_prefix}/lib/google/guest_agent/core_plugin
 %endif
 
 %if 0%{?el6}
@@ -118,6 +121,7 @@ install -p -m 0644 90-%{name}.preset %{buildroot}%{_presetdir}/90-%{name}.preset
 %{_bindir}/google_guest_compat_manager
 %{_bindir}/google_guest_agent_manager
 %{_bindir}/ggactl_plugin_cleanup
+%{_exec_prefix}/lib/google/guest_agent/core_plugin
 %endif
 
 %{_bindir}/google_metadata_script_runner


### PR DESCRIPTION
PR also fixes required permissions on the debian package binary. It makes it consistent with the rpm package and this is required as without `+x` permission plugin manager would fail to launch core plugin


/cc @dorileo @drewhli 