### PR TITLE
Update startup/shutdown services to launch compat manager

### DIFF
--- a/google-shutdown-scripts.service
+++ b/google-shutdown-scripts.service
@@ -8,7 +8,7 @@ Type=oneshot
 ExecStart=/bin/true
 RemainAfterExit=true
 # This service does nothing on start, and runs shutdown scripts on stop.
-ExecStop=/usr/bin/google_metadata_script_runner shutdown
+ExecStop=/bin/sh -c 'if [ -e /usr/bin/gce_compat_metadata_script_runner ]; then /usr/bin/gce_compat_metadata_script_runner shutdown; else /usr/bin/google_metadata_script_runner shutdown; fi'
 TimeoutStopSec=0
 KillMode=process
 

--- a/google-startup-scripts.service
+++ b/google-startup-scripts.service
@@ -6,7 +6,7 @@ Before=apt-daily.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/google_metadata_script_runner startup
+ExecStart=/bin/sh -c 'if [ -e /usr/bin/gce_compat_metadata_script_runner ]; then /usr/bin/gce_compat_metadata_script_runner startup; else /usr/bin/google_metadata_script_runner startup; fi'
 #TimeoutStartSec is ignored for Type=oneshot service units.
 KillMode=process
 StandardOutput=journal+console

--- a/packaging/googet/run_shutdown_scripts.cmd
+++ b/packaging/googet/run_shutdown_scripts.cmd
@@ -16,4 +16,8 @@ REM limitations under the License.
 REM Run shutdown scripts that should happen as soon as the instance
 REM begins to power down
 
-"C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "shutdown"
+IF EXIST "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" (
+    "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" "shutdown"
+) ELSE (
+    "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "shutdown"
+)

--- a/packaging/googet/run_startup_scripts.cmd
+++ b/packaging/googet/run_startup_scripts.cmd
@@ -19,4 +19,8 @@ REM A scheduled task may only run for up to three days before termination.
 REM We execute the startup script asynchronously so it may run without
 REM this three day maximum runtime limitation.
 
-start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "startup"
+IF EXIST "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" (
+    start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" "startup"
+) ELSE (
+    start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "startup"
+)


### PR DESCRIPTION
Update service files to  launch compat manager if present instead of  `google_metadata_script_runner`. `gce_compat_metadata_script_runner` will correctly launch either `google_metadata_script_runner` or `gce_metadata_script_runner` based on user setting

/cc @dorileo @drewhli 

/hold