### PR TITLE
Fix install path for core plugin

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -29,7 +29,7 @@ override_dh_auto_install:
 		install -p -m 0755 google-guest-agent/cmd/google_guest_compat_manager/google_guest_compat_manager debian/google-guest-agent/usr/bin/google_guest_compat_manager;\
 		install -p -m 0755 google-guest-agent/cmd/google_guest_agent/google_guest_agent debian/google-guest-agent/usr/bin/google_guest_agent_manager;\
 		install -p -m 0755 google-guest-agent/cmd/ggactl/ggactl_plugin_cleanup debian/google-guest-agent/usr/bin/ggactl_plugin_cleanup;\
-		install -p -m 0755 google-guest-agent/cmd/core_plugin/core_plugin debian/google-guest-agent/usr/lib/google/guest-agent/core_plugin;\
+		install -p -m 0755 google-guest-agent/cmd/core_plugin/core_plugin debian/google-guest-agent/usr/lib/google/guest_agent/core_plugin;\
 		install -p -m 0755 google-guest-agent/cmd/metadata_script_runner_compat/gce_compat_metadata_script_runner debian/google-guest-agent/usr/bin/gce_compat_metadata_script_runner;\
 	fi
 


### PR DESCRIPTION
Now it matches with what we have in [rpm spec](https://github.com/GoogleCloudPlatform/guest-agent/blob/7684de49fb87924980bf1fd423a51fa50dd25951/packaging/google-guest-agent.spec#L92) and other places

/cc @dorileo @drewhli 