### PR TITLE
oslogin: Correctly handle newlines at the end of modified files

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -228,7 +228,7 @@ func cleanupDeprecatedLines(fpath string, directives []string) error {
 		return nil
 	}
 
-	err = os.WriteFile(fpath, []byte(strings.Join(updatedLines, "\n")), stat.Mode())
+	err = os.WriteFile(fpath, []byte(strings.Join(updatedLines, "\n")+"\n"), stat.Mode())
 	if err != nil {
 		return fmt.Errorf("failed to update deprecated configuration directives: %+v", err)
 	}
@@ -264,6 +264,14 @@ func filterGoogleLines(contents string) []string {
 		default:
 			filtered = append(filtered, line)
 		}
+	}
+	// Unix text files should end with a final "\n"
+	// which strings.Split will account for with a terminal ""
+	// so we remove that here, to avoid adding more empty lines.
+	// But we can't assume that every file does end in a newline,
+	// so only remove it if it's empty as expected.
+	if len(filtered) > 0 && filtered[len(filtered)-1] == "" {
+		filtered = filtered[:len(filtered)-1]
 	}
 	return filtered
 }
@@ -331,7 +339,7 @@ func updateSSHConfig(sshConfig string, enable, twofactor, skey, reqCerts bool) s
 		}
 	}
 
-	return strings.Join(filtered, "\n")
+	return strings.Join(filtered, "\n") + "\n"
 }
 
 func writeSSHConfig(enable, twofactor, skey, reqCerts bool) error {
@@ -365,6 +373,7 @@ func updateNSSwitchConfig(nsswitch string, enable bool) string {
 		}
 		filtered = append(filtered, line)
 	}
+	// No trailing "\n" here because `filtered` will include an empty element at the end to account for it.
 	return strings.Join(filtered, "\n")
 }
 
@@ -402,7 +411,7 @@ func updatePAMsshdPamless(pamsshd string, enable, twofactor bool) string {
 		filtered = append(topOfFile, filtered...)
 		filtered = append(filtered, bottomOfFile...)
 	}
-	return strings.Join(filtered, "\n")
+	return strings.Join(filtered, "\n") + "\n"
 }
 
 func writePAMConfig(enable, twofactor bool) error {
@@ -429,7 +438,7 @@ func updateGroupConf(groupconf string, enable bool) string {
 		filtered = append(filtered, []string{googleComment, config}...)
 	}
 
-	return strings.Join(filtered, "\n")
+	return strings.Join(filtered, "\n") + "\n"
 }
 
 func writeGroupConf(enable bool) error {

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -121,7 +121,8 @@ func TestFilterGoogleLines(t *testing.T) {
 	}
 
 	for idx, tt := range tests {
-		if res := filterGoogleLines(strings.Join(tt.contents, "\n")); !cmpslice(res, tt.want) {
+		// The additional "\n" at the end is because Unix text files are expected to end in a newline
+		if res := filterGoogleLines(strings.Join(tt.contents, "\n") + "\n"); !cmpslice(res, tt.want) {
 			t.Errorf("test %v\nwant:\n%v\ngot:\n%v\n", idx, tt.want, res)
 		}
 	}
@@ -189,8 +190,8 @@ func TestUpdateNSSwitchConfig(t *testing.T) {
 	}
 
 	for idx, tt := range tests {
-		contents := strings.Join(tt.contents, "\n")
-		want := strings.Join(tt.want, "\n")
+		contents := strings.Join(tt.contents, "\n") + "\n"
+		want := strings.Join(tt.want, "\n") + "\n"
 
 		if res := updateNSSwitchConfig(contents, tt.enable); res != want {
 			t.Errorf("test %v\nwant:\n%v\ngot:\n%v\n", idx, want, res)
@@ -517,8 +518,8 @@ func TestUpdateSSHConfig(t *testing.T) {
 	defaultCertAuthConfig := config.OSLogin.CertAuthentication
 
 	for idx, tt := range tests {
-		contents := strings.Join(tt.contents, "\n")
-		want := strings.Join(tt.want, "\n")
+		contents := strings.Join(tt.contents, "\n") + "\n"
+		want := strings.Join(tt.want, "\n") + "\n"
 		config.OSLogin.CertAuthentication = tt.cfgCert
 
 		if res := updateSSHConfig(contents, tt.enable, tt.twofactor, tt.skey, tt.reqCerts); res != want {
@@ -595,8 +596,8 @@ func TestUpdatePAMsshdPamless(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("test-%d", idx), func(t *testing.T) {
-			contents := strings.Join(tt.contents, "\n")
-			want := strings.Join(tt.want, "\n")
+			contents := strings.Join(tt.contents, "\n") + "\n"
+			want := strings.Join(tt.want, "\n") + "\n"
 
 			if res := updatePAMsshdPamless(contents, tt.enable, tt.twofactor); res != want {
 				t.Errorf("want:\n%v\ngot:\n%v\n", want, res)
@@ -667,8 +668,8 @@ func TestUpdateGroupConf(t *testing.T) {
 	}
 
 	for idx, tt := range tests {
-		contents := strings.Join(tt.contents, "\n")
-		want := strings.Join(tt.want, "\n")
+		contents := strings.Join(tt.contents, "\n") + "\n"
+		want := strings.Join(tt.want, "\n") + "\n"
 
 		if res := updateGroupConf(contents, tt.enable); res != want {
 			t.Errorf("test %v\nwant:\n%v\ngot:\n%v\n", idx, want, res)


### PR DESCRIPTION
e38e673 oslogin: avoid adding extra empty line at the end of /etc/security/group.conf (#369)

had reverted:

b3376e8 end group.conf with newline (#64)

When really the problem that e38e673 was trying to solve was the handling of the terminal \n in filterGoogleLines()