### PR TITLE
Re-enable disabled services if the core plugin was enabled

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,9 +1,18 @@
 #!/bin/sh -e
 
 if [ "$1" = "configure" ] ; then
-	if [ ! -f /etc/default/instance_configs.cfg ]; then 
-		cp -a "/usr/share/${DPKG_MAINTSCRIPT_PACKAGE}/instance_configs.cfg" /etc/default/
-	fi
+  if [ ! -f /etc/default/instance_configs.cfg ]; then
+    cp -a "/usr/share/${DPKG_MAINTSCRIPT_PACKAGE}/instance_configs.cfg" /etc/default/
+  fi
+
+  if [ ! -f "/usr/bin/google_guest_compat_manager" ]; then
+    if [ -f "/etc/google-guest-agent/core-plugin-enabled" ] && [ ! -z $(grep "true" "/etc/google-guest-agent/core-plugin-enabled") ]; then
+      # If the guest agent is disabled because core plugin is enabled, then
+      # re-enable the guest agent. Otherwise it stays disabled post-upgrade.
+      systemctl enable 'google-guest-agent.service' > /dev/null || true
+      systemctl enable 'gce-workload-cert-refresh.timer' > /dev/null || true
+    fi
+  fi
 fi
 
 #DEBHELPER#

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -174,6 +174,15 @@ else
       systemctl restart google-guest-agent-manager.service >/dev/null 2>&1 || :
     %endif
   fi
+
+  # Re-enable the guest agent service if core plugin was enabled, since the
+  # service would have been disabled, and stay disabled post-upgrade.
+  if [ ! -f "/usr/bin/google_guest_compat_manager" ]; then
+    if [ -f "/etc/google-guest-agent/core-plugin-enabled" ] && [ ! -z $(grep "true" "/etc/google-guest-agent/core-plugin-enabled") ]; then
+      systemctl enable google-guest-agent.service > /dev/null 2>&1 || :
+      systemctl enable gce-workload-cert-refresh.timer > /dev/null 2>&1 || :
+    fi
+  fi
 fi
 
 %preun


### PR DESCRIPTION
From some testing, `deb-systemd-helper` skips services if manually disabled, so we have to use `systemctl` for the debian packaging.

One thing to consider is removing the `core-plugin-enabled` file. This is because in case a roll-forward package is released (let's call this package A), followed by another compat-manager-less package (let's call this package B), and the customer manually disabled the `google-guest-agent` service while on version A, then upgrading to B without removing the file means that the service gets re-enabled. Removing the file ensures that this case will not happen. However, we may not have an actual use-case for this, so I've left it out for now.

This seems to work as intended from some local package building and installation on both Debian and RHEL.

/cc @ChaitanyaKulkarni28 @dorileo