### PR TITLE
Revert "oslogin: Correctly handle newlines at the end of modified fil…

### DIFF
--- a/google_guest_agent/oslogin.go
+++ b/google_guest_agent/oslogin.go
@@ -228,7 +228,7 @@ func cleanupDeprecatedLines(fpath string, directives []string) error {
 		return nil
 	}
 
-	err = os.WriteFile(fpath, []byte(strings.Join(updatedLines, "\n")+"\n"), stat.Mode())
+	err = os.WriteFile(fpath, []byte(strings.Join(updatedLines, "\n")), stat.Mode())
 	if err != nil {
 		return fmt.Errorf("failed to update deprecated configuration directives: %+v", err)
 	}
@@ -264,14 +264,6 @@ func filterGoogleLines(contents string) []string {
 		default:
 			filtered = append(filtered, line)
 		}
-	}
-	// Unix text files should end with a final "\n"
-	// which strings.Split will account for with a terminal ""
-	// so we remove that here, to avoid adding more empty lines.
-	// But we can't assume that every file does end in a newline,
-	// so only remove it if it's empty as expected.
-	if len(filtered) > 0 && filtered[len(filtered)-1] == "" {
-		filtered = filtered[:len(filtered)-1]
 	}
 	return filtered
 }
@@ -339,7 +331,7 @@ func updateSSHConfig(sshConfig string, enable, twofactor, skey, reqCerts bool) s
 		}
 	}
 
-	return strings.Join(filtered, "\n") + "\n"
+	return strings.Join(filtered, "\n")
 }
 
 func writeSSHConfig(enable, twofactor, skey, reqCerts bool) error {
@@ -373,7 +365,6 @@ func updateNSSwitchConfig(nsswitch string, enable bool) string {
 		}
 		filtered = append(filtered, line)
 	}
-	// No trailing "\n" here because `filtered` will include an empty element at the end to account for it.
 	return strings.Join(filtered, "\n")
 }
 
@@ -411,7 +402,7 @@ func updatePAMsshdPamless(pamsshd string, enable, twofactor bool) string {
 		filtered = append(topOfFile, filtered...)
 		filtered = append(filtered, bottomOfFile...)
 	}
-	return strings.Join(filtered, "\n") + "\n"
+	return strings.Join(filtered, "\n")
 }
 
 func writePAMConfig(enable, twofactor bool) error {
@@ -438,7 +429,7 @@ func updateGroupConf(groupconf string, enable bool) string {
 		filtered = append(filtered, []string{googleComment, config}...)
 	}
 
-	return strings.Join(filtered, "\n") + "\n"
+	return strings.Join(filtered, "\n")
 }
 
 func writeGroupConf(enable bool) error {

--- a/google_guest_agent/oslogin_test.go
+++ b/google_guest_agent/oslogin_test.go
@@ -121,8 +121,7 @@ func TestFilterGoogleLines(t *testing.T) {
 	}
 
 	for idx, tt := range tests {
-		// The additional "\n" at the end is because Unix text files are expected to end in a newline
-		if res := filterGoogleLines(strings.Join(tt.contents, "\n") + "\n"); !cmpslice(res, tt.want) {
+		if res := filterGoogleLines(strings.Join(tt.contents, "\n")); !cmpslice(res, tt.want) {
 			t.Errorf("test %v\nwant:\n%v\ngot:\n%v\n", idx, tt.want, res)
 		}
 	}
@@ -190,8 +189,8 @@ func TestUpdateNSSwitchConfig(t *testing.T) {
 	}
 
 	for idx, tt := range tests {
-		contents := strings.Join(tt.contents, "\n") + "\n"
-		want := strings.Join(tt.want, "\n") + "\n"
+		contents := strings.Join(tt.contents, "\n")
+		want := strings.Join(tt.want, "\n")
 
 		if res := updateNSSwitchConfig(contents, tt.enable); res != want {
 			t.Errorf("test %v\nwant:\n%v\ngot:\n%v\n", idx, want, res)
@@ -518,8 +517,8 @@ func TestUpdateSSHConfig(t *testing.T) {
 	defaultCertAuthConfig := config.OSLogin.CertAuthentication
 
 	for idx, tt := range tests {
-		contents := strings.Join(tt.contents, "\n") + "\n"
-		want := strings.Join(tt.want, "\n") + "\n"
+		contents := strings.Join(tt.contents, "\n")
+		want := strings.Join(tt.want, "\n")
 		config.OSLogin.CertAuthentication = tt.cfgCert
 
 		if res := updateSSHConfig(contents, tt.enable, tt.twofactor, tt.skey, tt.reqCerts); res != want {
@@ -596,8 +595,8 @@ func TestUpdatePAMsshdPamless(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("test-%d", idx), func(t *testing.T) {
-			contents := strings.Join(tt.contents, "\n") + "\n"
-			want := strings.Join(tt.want, "\n") + "\n"
+			contents := strings.Join(tt.contents, "\n")
+			want := strings.Join(tt.want, "\n")
 
 			if res := updatePAMsshdPamless(contents, tt.enable, tt.twofactor); res != want {
 				t.Errorf("want:\n%v\ngot:\n%v\n", want, res)
@@ -668,8 +667,8 @@ func TestUpdateGroupConf(t *testing.T) {
 	}
 
 	for idx, tt := range tests {
-		contents := strings.Join(tt.contents, "\n") + "\n"
-		want := strings.Join(tt.want, "\n") + "\n"
+		contents := strings.Join(tt.contents, "\n")
+		want := strings.Join(tt.want, "\n")
 
 		if res := updateGroupConf(contents, tt.enable); res != want {
 			t.Errorf("test %v\nwant:\n%v\ngot:\n%v\n", idx, want, res)


### PR DESCRIPTION
…es (#520)"

This reverts commit 8bfcaae8cf8edd0f9be5d87590740b016300b646 introduced with PR #520.