### PR TITLE
Wicked: Only reload interfaces for which configurations are written or changed.

### DIFF
--- a/google_guest_agent/network/manager/wicked_linux.go
+++ b/google_guest_agent/network/manager/wicked_linux.go
@@ -103,11 +103,13 @@ func (n *wicked) SetupEthernetInterface(ctx context.Context, cfg *cfg.Sections, 
 	}
 
 	// https://manpages.opensuse.org/Tumbleweed/wicked/wicked.8.en.html#ifreload_-_checks_whether_a_configuration_has_changed,_and_applies_accordingly.
-	// Apply any configuration changes on all interface. If unchanged ifreload
-	// does not touch specified interfaces.
-	args := append([]string{"ifreload"}, changed...)
-	if err = run.Quiet(ctx, n.wickedCommand, args...); err != nil {
-		return fmt.Errorf("error enabling interfaces: %v", err)
+	// Only apply configuration changes for interfaces for which configurations
+	// were written or changed.
+	if len(changed) > 0 {
+		args := append([]string{"ifreload"}, changed...)
+		if err = run.Quiet(ctx, n.wickedCommand, args...); err != nil {
+			return fmt.Errorf("error enabling interfaces: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
`wicked ifreload all` fails if there are any lingering configuration files that apply to an interface that either does not exist or has been made invalid. The rollback logic in this case would fail to clean up these dangling files because no interfaces would match the name, thus leaving this hanging configuration file. This is a workaround for this case to avoid network setup failing so that the rest of the network setup like IP-forwarding route setup can complete.

/cc @ChaitanyaKulkarni28 @dorileo 
/hold