### PR TITLE
Remove error messages from cert refresher and metadata script runner

### DIFF
--- a/gce_workload_cert_refresh/main.go
+++ b/gce_workload_cert_refresh/main.go
@@ -149,16 +149,15 @@ type outputOpts struct {
 
 func main() {
 	ctx := context.Background()
-	createdByBytes, err := getMetadata(ctx, "/instance/attributes/created-by")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting metadata attribute created-by: %v\n", err)
-	}
 	opts := logger.LogOpts{
 		LoggerName:     programName,
 		FormatFunction: logFormat,
 		// No need for syslog.
 		DisableLocalLogging: true,
-		MIG:                 string(createdByBytes),
+	}
+	createdByBytes, err := getMetadata(ctx, "/instance/attributes/created-by")
+	if err == nil {
+		opts.MIG = string(createdByBytes)
 	}
 
 	opts.Writers = []io.Writer{os.Stderr}

--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -453,10 +453,9 @@ func main() {
 		opts.ProjectName = projectID
 	}
 	createdBy, err := getMetadataKey(ctx, "/instance/attributes/created-by")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting metadata attribute created-by: %v", err)
+	if err == nil {
+		opts.MIG = createdBy
 	}
-	opts.MIG = createdBy
 
 	if err := logger.Init(ctx, opts); err != nil {
 		fmt.Printf("Error initializing logger: %+v", err)


### PR DESCRIPTION
The addition of these error messages cause a lot of noise in the serial port logs. Keeping these logs silent will reduce the noise back to where it was before these changes.

/cc @ChaitanyaKulkarni28 @dorileo 