### PR TITLE
selinux: introduce policy module

### DIFF
--- a/selinux/google_guest_agent.fc
+++ b/selinux/google_guest_agent.fc
@@ -1,0 +1,19 @@
+/usr/bin/google_guest_agent_manager		--	gen_context(system_u:object_r:google_guest_agent_exec_t,s0)
+
+/usr/bin/google_guest_agent		--	gen_context(system_u:object_r:google_guest_agent_exec_t,s0)
+
+/usr/bin/google_metadata_script_runner		--	gen_context(system_u:object_r:google_guest_agent_exec_t,s0)
+
+/usr/lib/systemd/system-preset/90-google-guest-agent.preset		--	gen_context(system_u:object_r:google_guest_agent_unit_file_t,s0)
+
+/usr/lib/systemd/system/gce-workload-cert-refresh.service		--	gen_context(system_u:object_r:google_guest_agent_unit_file_t,s0)
+
+/usr/lib/systemd/system/gce-workload-cert-refresh.timer		--	gen_context(system_u:object_r:google_guest_agent_unit_file_t,s0)
+
+/usr/lib/systemd/system/google-guest-agent-manager.service		--	gen_context(system_u:object_r:google_guest_agent_unit_file_t,s0)
+
+/usr/lib/systemd/system/google-guest-agent.service		--	gen_context(system_u:object_r:google_guest_agent_unit_file_t,s0)
+
+/usr/lib/systemd/system/google-shutdown-scripts.service		--	gen_context(system_u:object_r:google_guest_agent_unit_file_t,s0)
+
+/usr/lib/systemd/system/google-startup-scripts.service		--	gen_context(system_u:object_r:google_guest_agent_unit_file_t,s0)

--- a/selinux/google_guest_agent.if
+++ b/selinux/google_guest_agent.if
@@ -1,0 +1,103 @@
+
+## <summary>policy for google_guest_agent</summary>
+
+########################################
+## <summary>
+##	Execute google_guest_agent_exec_t in the google_guest_agent domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`google_guest_agent_domtrans',`
+	gen_require(`
+		type google_guest_agent_t, google_guest_agent_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, google_guest_agent_exec_t, google_guest_agent_t)
+')
+
+######################################
+## <summary>
+##	Execute google_guest_agent in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`google_guest_agent_exec',`
+	gen_require(`
+		type google_guest_agent_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, google_guest_agent_exec_t)
+')
+########################################
+## <summary>
+##	Execute google_guest_agent server in the google_guest_agent domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`google_guest_agent_systemctl',`
+	gen_require(`
+		type google_guest_agent_t;
+		type google_guest_agent_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 google_guest_agent_unit_file_t:file read_file_perms;
+	allow $1 google_guest_agent_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, google_guest_agent_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an google_guest_agent environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`google_guest_agent_admin',`
+	gen_require(`
+		type google_guest_agent_t;
+	type google_guest_agent_unit_file_t;
+	')
+
+	allow $1 google_guest_agent_t:process { signal_perms };
+	ps_process_pattern($1, google_guest_agent_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 google_guest_agent_t:process ptrace;
+    ')
+
+	google_guest_agent_systemctl($1)
+	admin_pattern($1, google_guest_agent_unit_file_t)
+	allow $1 google_guest_agent_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/selinux/google_guest_agent.te
+++ b/selinux/google_guest_agent.te
@@ -1,0 +1,28 @@
+policy_module(google_guest_agent, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type google_guest_agent_t;
+type google_guest_agent_exec_t;
+init_daemon_domain(google_guest_agent_t, google_guest_agent_exec_t)
+
+permissive google_guest_agent_t;
+
+type google_guest_agent_unit_file_t;
+systemd_unit_file(google_guest_agent_unit_file_t)
+
+########################################
+#
+# google_guest_agent local policy
+#
+allow google_guest_agent_t self:fifo_file rw_fifo_file_perms;
+allow google_guest_agent_t self:unix_stream_socket create_stream_socket_perms;
+
+domain_use_interactive_fds(google_guest_agent_t)
+
+files_read_etc_files(google_guest_agent_t)
+
+miscfiles_read_localization(google_guest_agent_t)


### PR DESCRIPTION
Introduce a guest-agent selinux policy. Build and packaging to follow in an upcoming PR.

To manually build and install, in a EL 9 system do:
 - install policycoreutils-devel package
 - cd selinux && make -f /usr/share/selinux/devel/Makefile google_guest_agent.pp
 - sudo /usr/sbin/semodule -i google_guest_agent.pp
 - sudo restorecon /usr/bin/google_metadata_*
 - sudo systemctl restart google-guest-agent && sudo systemctl restart google-guest-agent-manager