### PR TITLE
Make sure agent added connections are activated by NM

### DIFF
--- a/google_guest_agent/network/manager/network_manager_linux_test.go
+++ b/google_guest_agent/network/manager/network_manager_linux_test.go
@@ -394,10 +394,6 @@ func TestWriteNetworkManagerConfigs(t *testing.T) {
 			}
 
 			for i, conn := range conns {
-				if conn != test.wantInterfaces[i] {
-					t.Fatalf("unexpected connection interface. Expected: %s, Actual: %s", test.wantInterfaces[i], conn)
-				}
-
 				// Load the file and check the sections.
 				configFilePath := path.Join(configDir, test.expectedFiles[i])
 				opts := ini.LoadOptions{
@@ -419,8 +415,8 @@ func TestWriteNetworkManagerConfigs(t *testing.T) {
 					t.Fatalf("guest-agent's managed key is set to false, expected true")
 				}
 
-				if config.Connection.ID != test.expectedIDs[i] {
-					t.Fatalf("unexpected connection id. Expected: %v, Actual: %v", test.expectedIDs[i], config.Connection.ID)
+				if config.Connection.ID != conn {
+					t.Fatalf("unexpected connection id. Expected: %v, Actual: %v", conn, config.Connection.ID)
 				}
 
 				if config.Connection.InterfaceName != test.wantInterfaces[i] {


### PR DESCRIPTION
If the ID is not given an `ifname` is required, and NetworkManager will activate the best available connection for the given `ifname` - This NM behavior causes agent written connections to be not active and it continues to run default profiles. This change ensures we're referring them by connection ID and explicitly bringing them up.

Refer [this](https://networkmanager.dev/docs/api/latest/nmcli.html#:~:text=Activate%20a%20connection,Wi%2DFi%20connection.) NM docs for context. 

/cc @dorileo @drewhli 

/hold