### PR TITLE
Update killmode, systemd should manage only the main process

### DIFF
--- a/google-guest-agent-manager.service
+++ b/google-guest-agent-manager.service
@@ -8,6 +8,7 @@ Type=notify
 ExecStart=/usr/bin/google_guest_agent_manager
 OOMScoreAdjust=-999
 Restart=always
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Set `KillMode=process` instead of default control-group. systemd should manage only the main process and must not kill/stop plugin processes spawned by Guest Agent Manager.

/cc @dorileo @drewhli 