### PR TITLE
Startup scripts should start after agent manager instead

### DIFF
--- a/google-startup-scripts.service
+++ b/google-startup-scripts.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Google Compute Engine Startup Scripts
 Wants=network-online.target rsyslog.service
-After=network-online.target rsyslog.service google-guest-agent.service
+After=network-online.target rsyslog.service google-guest-agent-manager.service
 Before=apt-daily.service
 
 [Service]


### PR DESCRIPTION
Now that `google-guest-agent.service` is disabled by default startup script should be started after `google-guest-agent-manager.service` instead

