### PR TITLE
Add config options for ignoring forwarded IPs.

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -304,8 +304,13 @@ func (a *addressMgr) Set(ctx context.Context) error {
 			}
 			continue
 		}
-		wantIPs := ni.ForwardedIps
-		wantIPs = append(wantIPs, ni.ForwardedIpv6s...)
+		wantIPs := []string{}
+		if config.IPForwarding.ForwardedIPs {
+			wantIPs = append(wantIPs, ni.ForwardedIps...)
+		}
+		if config.IPForwarding.ForwardedIpv6s {
+			wantIPs = append(wantIPs, ni.ForwardedIpv6s...)
+		}
 		if config.IPForwarding.TargetInstanceIPs {
 			wantIPs = append(wantIPs, ni.TargetInstanceIps...)
 		}

--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -61,6 +61,8 @@ network_daemon = true
 
 [IpForwarding]
 ethernet_proto_id = 66
+forwarded_ips = true
+forwarded_ipv6s = true
 ip_aliases = true
 target_instance_ips = true
 
@@ -226,6 +228,8 @@ type Diagnostics struct {
 // IPForwarding contains the configurations of IPForwarding section.
 type IPForwarding struct {
 	EthernetProtoID   string `ini:"ethernet_proto_id,omitempty"`
+	ForwardedIPs      bool   `ini:"forwarded_ips,omitempty"`
+	ForwardedIpv6s    bool   `ini:"forwarded_ipv6s,omitempty"`
 	IPAliases         bool   `ini:"ip_aliases,omitempty"`
 	TargetInstanceIPs bool   `ini:"target_instance_ips,omitempty"`
 }


### PR DESCRIPTION
This is done through the same way as how TargetInstanceIPs are implemented.

I do noticed there is a new repo [google-guest-agent](https://github.com/GoogleCloudPlatform/google-guest-agent) exists - please kindly let me know if this is something under consideration and whether I should implement the same thing there. Thanks!

Fixes https://github.com/GoogleCloudPlatform/guest-agent/issues/555.