### PR TITLE
Revert compat behavior and call known binary directly

### DIFF
--- a/google_metadata_script_runner_adapt
+++ b/google_metadata_script_runner_adapt
@@ -2,11 +2,9 @@
 #
 # This script wraps compatibility logic of guest agent's startup script
 # runner. If compat manager is present run it, otherwise launch the
-# known service binary.
+# known service binary. In case the package is to revert back to previous
+# version of guest-agent without core plugin it directly launches known service 
+# binary.
 #
 
-if [ -e /usr/bin/gce_compat_metadata_script_runner ]; then
-  /usr/bin/gce_compat_metadata_script_runner startup
-else
-  /usr/bin/google_metadata_script_runner startup
-fi
+/usr/bin/google_metadata_script_runner startup

--- a/packaging/googet/run_shutdown_scripts.cmd
+++ b/packaging/googet/run_shutdown_scripts.cmd
@@ -16,8 +16,5 @@ REM limitations under the License.
 REM Run shutdown scripts that should happen as soon as the instance
 REM begins to power down
 
-IF EXIST "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" (
-    "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" "shutdown"
-) ELSE (
-    "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "shutdown"
-)
+"C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "shutdown"
+

--- a/packaging/googet/run_startup_scripts.cmd
+++ b/packaging/googet/run_startup_scripts.cmd
@@ -19,8 +19,4 @@ REM A scheduled task may only run for up to three days before termination.
 REM We execute the startup script asynchronously so it may run without
 REM this three day maximum runtime limitation.
 
-IF EXIST "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" (
-    start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCECompatMetadataScripts.exe" "startup"
-) ELSE (
-    start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "startup"
-)
+start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "startup"


### PR DESCRIPTION
This is for rollforward package and works as if compat is disabled.

/cc @dorileo @drewhli 