### PR TITLE
Fix adapt to use more portable shebang line

### DIFF
--- a/google_metadata_script_runner_adapt
+++ b/google_metadata_script_runner_adapt
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 #
 # This script wraps compatibility logic of guest agent's startup script
 # runner. If compat manager is present run it, otherwise launch the


### PR DESCRIPTION
Current approach especially fails on ubuntu 18.04 pro with error `/bin/env: bad interpreter: No such file or directory`

Stable branch updated in #568

/cc @dorileo @drewhli 