### PR TITLE
fix(lint): Correct non-constant format string errors

### DIFF
--- a/google_guest_agent/addresses.go
+++ b/google_guest_agent/addresses.go
@@ -368,7 +368,7 @@ func (a *addressMgr) Set(ctx context.Context) error {
 				}
 				msg += fmt.Sprintf(" removing %q", toRm)
 			}
-			logger.Infof(msg)
+			logger.Infof("%s", msg)
 		}
 
 		var registryEntries []string

--- a/google_guest_agent/diagnostics.go
+++ b/google_guest_agent/diagnostics.go
@@ -126,7 +126,7 @@ func (d *diagnosticsMgr) Set(ctx context.Context) error {
 	go func() {
 		logger.Infof("Diagnostics: collecting logs from the system.")
 		res := run.WithCombinedOutput(ctx, diagnosticsCmd, args...)
-		logger.Infof(res.Combined)
+		logger.Infof("%s", res.Combined)
 		if res.ExitCode != 0 {
 			logger.Warningf("Error collecting logs: %v", res.Error())
 		}

--- a/google_guest_agent/events/sshtrustedca/sshtrustedca_linux.go
+++ b/google_guest_agent/events/sshtrustedca/sshtrustedca_linux.go
@@ -46,7 +46,7 @@ func createNamedPipe(ctx context.Context, pipePath string) error {
 				return fmt.Errorf("failed to create named pipe: %+v", err)
 			}
 		} else {
-			return fmt.Errorf("failed to stat file: " + pipePath)
+			return fmt.Errorf("failed to stat file: %s", pipePath)
 		}
 	}
 

--- a/google_guest_agent/windows_accounts.go
+++ b/google_guest_agent/windows_accounts.go
@@ -344,7 +344,7 @@ func (a *winAccountsMgr) Set(ctx context.Context) error {
 		if sshEnable != oldSSHEnable {
 			err := verifyWinSSHVersion(ctx)
 			if err != nil {
-				logger.Warningf(err.Error())
+				logger.Warningf("%s", err.Error())
 			}
 
 			if !checkWindowsServiceRunning(ctx, "sshd") {

--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -469,7 +469,7 @@ func main() {
 
 	scripts, err := getExistingKeys(ctx, wantedKeys)
 	if err != nil {
-		logger.Fatalf(err.Error())
+		logger.Fatalf("%s", err.Error())
 	}
 
 	if len(scripts) == 0 {

--- a/google_metadata_script_runner/main_test.go
+++ b/google_metadata_script_runner/main_test.go
@@ -317,7 +317,7 @@ func TestDownloadURL(t *testing.T) {
 			w.WriteHeader(400)
 		}
 
-		fmt.Fprintf(w, r.URL.Path)
+		fmt.Fprintf(w, "%s", r.URL.Path)
 		ctr[r.URL.Path] = ctr[r.URL.Path] + 1
 	}))
 	defer server.Close()
@@ -386,7 +386,7 @@ func TestDownloadGSURL(t *testing.T) {
 		if strings.Contains(r.URL.Path, "invalid") {
 			w.WriteHeader(404)
 		}
-		fmt.Fprintf(w, r.URL.Path)
+		fmt.Fprintf(w, "%s", r.URL.Path)
 		ctr[r.URL.Path] = ctr[r.URL.Path] + 1
 	}))
 	defer server.Close()


### PR DESCRIPTION
Multiple calls to printf-style logging and error functions (`logger.Infof`, `fmt.Errorf`, `fmt.Fprintf`, etc.) were using variables as the format string, an unsafe pattern flagged by `go vet`.