### PR TITLE
Restart agent if core plugin is disabled

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -14,9 +14,15 @@ if [ "$1" = "configure" ] ; then
     fi
   fi
 
-  # Disable and stop this service in favor of core plugin to be run on default.
-  systemctl disable 'google-guest-agent.service' > /dev/null || true
-  systemctl stop 'google-guest-agent.service' > /dev/null || true
+  if grep -q "false" "/etc/google-guest-agent/core-plugin-enabled"; then
+    # If the core plugin was disabled, honor that setting.
+    systemctl enable google-guest-agent.service >/dev/null 2>&1 || :
+    systemctl start google-guest-agent.service >/dev/null 2>&1 || :
+  else
+    # Disable and stop this service in favor of core plugin to be run on default.
+    systemctl disable 'google-guest-agent.service' > /dev/null || true
+    systemctl stop 'google-guest-agent.service' > /dev/null || true
+  fi
 fi
 
 #DEBHELPER#

--- a/packaging/google-guest-agent.spec
+++ b/packaging/google-guest-agent.spec
@@ -195,7 +195,12 @@ else
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :
     %if 0%{?build_plugin_manager}
-      systemctl stop google-guest-agent.service >/dev/null 2>&1 || :
+      if grep -q "false" "/etc/google-guest-agent/core-plugin-enabled"; then
+        systemctl enable google-guest-agent.service >/dev/null 2>&1 || :
+        systemctl start google-guest-agent.service >/dev/null 2>&1 || :
+      else
+        systemctl stop google-guest-agent.service >/dev/null 2>&1 || :
+      fi
       systemctl restart google-guest-compat-manager.service >/dev/null 2>&1 || :
       systemctl restart google-guest-agent-manager.service >/dev/null 2>&1 || :
     %endif


### PR DESCRIPTION
Based on user setting core plugin might be disabled. Honor that setting during upgrade and launch non-plugin based agent to continue running.

/cc @dorileo @drewhli 

