### PR TITLE
Don't delete the authorized_keys file

### DIFF
--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -412,7 +412,7 @@ func createSudoersGroup(ctx context.Context, config *cfg.Sections) error {
 // updateAuthorizedKeysFile adds provided keys to the user's SSH
 // AuthorizedKeys file. The file and containing directory are created if it
 // does not exist. Uses a temporary file to avoid partial updates in case of
-// errors. If no keys are provided, the authorized keys file is removed.
+// errors.
 func updateAuthorizedKeysFile(ctx context.Context, user string, keys []string) error {
 	gcomment := "# Added by Google"
 
@@ -442,12 +442,6 @@ func updateAuthorizedKeysFile(ctx context.Context, user string, keys []string) e
 		}
 	}
 	akpath := path.Join(sshpath, "authorized_keys")
-	// Remove empty file.
-	if len(keys) == 0 {
-		os.Remove(akpath)
-		return nil
-	}
-
 	tempPath := akpath + ".google"
 	akcontents, err := os.ReadFile(akpath)
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
`updateAuthorizedKeysFile` takes great pains to preserve local user keys while updating the `authorized_keys` file... and then in other circumstances it blithely deletes the whole file. For a function named "update," it sure does more than updating...

This seems to be generally unexpected by the rest of the code (despite the doc comment mentioning the behaviour), and this (somewhat unpredictable) deletion behaviour interferes with users' ability to create and manage local accounts alongside Cloud-provisioned ones (either via `sshKeys` metadata, or OS Login).

As far as I can tell, simply removing the bit of code that deletes the file should make the `updateAuthorizedKeysFile` function operate in the way that the rest of the code expects; passing an empty list of `keys` will cause it to preserve the preexisting local user keys, but delete the Google-added ones, as desired.