### PR TITLE
fix start mode for windows on stable release

### DIFF
--- a/packaging/googet/agent_install.ps1
+++ b/packaging/googet/agent_install.ps1
@@ -103,7 +103,6 @@ try {
     $initial_config | Set-Content -Path $config -Encoding ASCII
   }
 
-  & sc.exe config $name start=auto
   Restart-Service $name -Verbose
 
   if ($install_manager) {


### PR DESCRIPTION
We have previously changed the start mode for guest agent service for
windows on stable release, this change reverts back to previous
behavior of delayed-auto.