### PR TITLE
Fix improper umask calculation on socket creation

### DIFF
--- a/google_guest_agent/command/command_linux.go
+++ b/google_guest_agent/command/command_linux.go
@@ -119,7 +119,7 @@ func listen(ctx context.Context, pipe string, filemode int, grp string) (net.Lis
 	// Mutating the umask of the process for this is not ideal, but tightening permissions with chown after creation is not really secure.
 	// Lock OS thread while mutating umask so we don't lose a thread with a mutated mask.
 	runtime.LockOSThread()
-	oldmask := syscall.Umask(777 - filemode)
+	oldmask := syscall.Umask(0777 - filemode)
 	var lc net.ListenConfig
 	l, err := lc.Listen(ctx, "unix", pipe)
 	syscall.Umask(oldmask)


### PR DESCRIPTION
This commit fixes a subtle bug with umask calculation when the guest-agent command monitor is creating the unix domain socket. The buggy calculation uses the demical 777 instead of octal 0777. This means that if `filemode` is 0770, which is the default value defined in `google_guest_agent/command/command_monitor.go`, then the actual computed umask is:

777 (dec) - 504 (dec) = 273 (dec) = 0421 (oct)

Which is a nonsensical umask for our purpose.