### PR TITLE
[2/3] Fallback to shebang execution when running scripts

### DIFF
--- a/google_metadata_script_runner/main.go
+++ b/google_metadata_script_runner/main.go
@@ -22,6 +22,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -292,7 +293,12 @@ func runScript(filePath string, metadataKey string) error {
 		if runtime.GOOS == "windows" {
 			cmd = exec.Command(filePath)
 		} else {
-			cmd = exec.Command(cfg.Get().MetadataScripts.DefaultShell, "-c", filePath)
+			_, err := os.Stat(cfg.Get().MetadataScripts.DefaultShell)
+			if errors.Is(err, os.ErrNotExist) {
+				cmd = exec.Command(filePath)
+			} else {
+				cmd = exec.Command(cfg.Get().MetadataScripts.DefaultShell, "-c", filePath)
+			}
 		}
 	}
 	return runCmd(cmd, metadataKey)


### PR DESCRIPTION
**Expected changes to Linux behavior**: Linux will also fallback to executing the script directly if `/bin/bash` does not exist.

The `google_metadata_script_runner` uses the default shell set in the
`google_guest_agent/cfg` package, which is `/bin/bash`. On systems that
do not have bash at that location or do not have bash installed at all
(namely FreeBSD), fallback to executing the script directly and rely on
the shebang in the script.
This change allows FreeBSD to run startup scripts in GCE.