### PR TITLE
[3/3] Support accounts manager on FreeBSD

### DIFF
--- a/google_guest_agent/cfg/cfg.go
+++ b/google_guest_agent/cfg/cfg.go
@@ -118,6 +118,85 @@ command_pipe_group =
 command_request_timeout = 10s
 systemd_config_dir = /usr/lib/systemd/network
 `
+
+	defaultConfigFreeBSD = `
+[Core]
+cloud_logging_enabled = true
+
+[Accounts]
+deprovision_remove = false
+gpasswd_add_cmd = pw groupmod {group} -m {user}
+gpasswd_remove_cmd = pw groupmod {group} -d {user}
+groupadd_cmd = pw groupadd {group}
+groups = adm,dip,docker,lxd,plugdev,video
+reuse_homedir = false
+useradd_cmd = pw useradd {user} -m -s /bin/sh -h -
+userdel_cmd = pw userdel {user} -r
+
+[Daemons]
+accounts_daemon = true
+clock_skew_daemon = true
+network_daemon = true
+
+[IpForwarding]
+ethernet_proto_id = 66
+ip_aliases = true
+target_instance_ips = true
+
+[Instance]
+instance_id =
+instance_id_dir = /etc/google_instance_id
+
+[InstanceSetup]
+host_key_dir = /etc/ssh
+host_key_types = ecdsa,ed25519,rsa
+network_enabled = true
+optimize_local_ssd = true
+set_boto_config = true
+set_host_keys = true
+set_multiqueue = true
+
+[MetadataScripts]
+default_shell = /bin/bash
+run_dir =
+shutdown = true
+shutdown-windows = true
+startup = true
+startup-windows = true
+sysprep-specialize = true
+
+[NetworkInterfaces]
+dhcp_command =
+ip_forwarding = true
+setup = true
+manage_primary_nic =
+restore_debian12_netplan_config = true
+vlan_setup_enabled = false
+
+[OSLogin]
+cert_authentication = true
+
+[MDS]
+disable-https-mds-setup = true
+enable-https-mds-native-cert-store = false
+
+[Routes]
+enable_monitor = false
+monitor_interval = 10s
+
+[Snapshots]
+enabled = false
+snapshot_service_ip = 169.254.169.254
+snapshot_service_port = 8081
+timeout_in_seconds = 60
+
+[Unstable]
+command_monitor_enabled = false
+command_pipe_mode = 0770
+command_pipe_group =
+command_request_timeout = 10s
+systemd_config_dir = /usr/lib/systemd/network
+`
 )
 
 // Core contains the core configuration entries of guest agent, all
@@ -339,7 +418,16 @@ func defaultConfigFile(osName string) string {
 }
 
 func defaultDataSources(extraDefaults []byte) []interface{} {
-	var res = []interface{}{[]byte(defaultConfig)}
+	var defaultConf string
+
+	switch os := runtime.GOOS; os {
+	case "freebsd":
+		defaultConf = defaultConfigFreeBSD
+	default:
+		defaultConf = defaultConfig
+	}
+
+	var res = []interface{}{[]byte(defaultConf)}
 	config := configFile(runtime.GOOS)
 
 	if len(extraDefaults) > 0 {

--- a/google_guest_agent/cfg/cfg_freebsd.go
+++ b/google_guest_agent/cfg/cfg_freebsd.go
@@ -1,0 +1,12 @@
+package cfg
+
+const (
+	// InstallPathPrefix is /usr/local for all third-party
+	// software in FreeBSD.
+	InstallPathPrefix = "/usr/local"
+
+	// DataPathPrefix is where applications store their persistent,
+	// dynamic data.
+	// In FreeBSD, /var/db is designated for this purpose.
+	DataPathPrefix = "/var/db"
+)

--- a/google_guest_agent/cfg/cfg_freebsd_test.go
+++ b/google_guest_agent/cfg/cfg_freebsd_test.go
@@ -1,0 +1,22 @@
+package cfg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserCmdsSanity(t *testing.T) {
+	if err := Load(nil); err != nil {
+		t.Fatalf("Failed to load configuration: %+v", err)
+	}
+
+	c := Get()
+
+	if !strings.HasPrefix(c.Accounts.GPasswdAddCmd, "pw ") ||
+		!strings.HasPrefix(c.Accounts.GPasswdRemoveCmd, "pw ") ||
+		!strings.HasPrefix(c.Accounts.UserAddCmd, "pw ") ||
+		!strings.HasPrefix(c.Accounts.GroupAddCmd, "pw ") ||
+		!strings.HasPrefix(c.Accounts.UserDelCmd, "pw ") {
+		t.Errorf("FreeBSD uses the pw command to manage users and groups")
+	}
+}

--- a/google_guest_agent/cfg/cfg_linux.go
+++ b/google_guest_agent/cfg/cfg_linux.go
@@ -1,0 +1,10 @@
+package cfg
+
+const (
+	// InstallPathPrefix is / on Linux because the Guest Agent and related
+	// files are installed directly relative to root like /usr and /etc.
+	InstallPathPrefix = "/"
+
+	// DataPathPrefix is the path prefix for persistent application data.
+	DataPathPrefix = "/var/lib"
+)

--- a/google_guest_agent/cfg/cfg_windows.go
+++ b/google_guest_agent/cfg/cfg_windows.go
@@ -1,0 +1,6 @@
+package cfg
+
+const (
+	InstallPathPrefix = "not-used"
+	DataPathPrefix    = "not-used"
+)

--- a/google_guest_agent/non_windows_accounts.go
+++ b/google_guest_agent/non_windows_accounts.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"sort"
@@ -38,7 +39,7 @@ var (
 	// sshKeys is a cache of what we have added to each managed users' authorized
 	// keys file. Avoids necessity of re-reading all files on every change.
 	sshKeys         map[string][]string
-	googleUsersFile = "/var/lib/google/google_users"
+	googleUsersFile = "/google/google_users"
 )
 
 // compareStringSlice returns true if two string slices are equal, false
@@ -299,14 +300,16 @@ func getPasswd(user string) (*passwdEntry, error) {
 }
 
 func writeGoogleUsersFile() error {
-	dir := path.Dir(googleUsersFile)
+	googleUsersFilePath := filepath.Join(cfg.DataPathPrefix, googleUsersFile)
+
+	dir := path.Dir(googleUsersFilePath)
 	if _, err := os.Stat(dir); err != nil {
 		if err = os.Mkdir(dir, 0755); err != nil {
 			return err
 		}
 	}
 
-	gfile, err := os.OpenFile(googleUsersFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	gfile, err := os.OpenFile(googleUsersFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err == nil {
 		defer gfile.Close()
 		for user := range sshKeys {
@@ -317,8 +320,9 @@ func writeGoogleUsersFile() error {
 }
 
 func readGoogleUsersFile() (map[string]string, error) {
+	googleUsersFilePath := filepath.Join(cfg.DataPathPrefix, googleUsersFile)
 	res := make(map[string]string)
-	gUsers, err := os.ReadFile(googleUsersFile)
+	gUsers, err := os.ReadFile(googleUsersFilePath)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -381,7 +385,13 @@ func removeGoogleUser(ctx context.Context, config *cfg.Sections, user string) er
 // not exist and specifies the group 'google-sudoers' should have all
 // permissions.
 func createSudoersFile() error {
-	sudoFile, err := os.OpenFile("/etc/sudoers.d/google_sudoers", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0440)
+	sudoersFilePath := filepath.Join(cfg.InstallPathPrefix, "/etc/sudoers.d/google_sudoers")
+
+	if err := os.MkdirAll(filepath.Dir(sudoersFilePath), 0755); err != nil {
+		return err
+	}
+
+	sudoFile, err := os.OpenFile(sudoersFilePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0440)
 	if err != nil {
 		if os.IsExist(err) {
 			return nil
@@ -398,14 +408,18 @@ func createSudoersGroup(ctx context.Context, config *cfg.Sections) error {
 	groupadd := config.Accounts.GroupAddCmd
 	name, args := createUserGroupCmd(groupadd, "", "google-sudoers")
 	ret := run.WithOutput(ctx, name, args...)
-	if ret.ExitCode == 9 {
-		// 9 means group already exists.
+	if runtime.GOOS == "linux" && ret.ExitCode == 9 {
+		// 9 means group already exists in Linux.
+		return nil
+	}
+	if runtime.GOOS == "freebsd" && ret.ExitCode == 65 {
+		// 65 means group already exists in FreeBSD.
 		return nil
 	}
 	if ret.ExitCode != 0 {
 		return error(ret)
 	}
-	logger.Infof("Created google sudoers file")
+	logger.Infof("Created google sudoers group")
 	return nil
 }
 


### PR DESCRIPTION
**Expected changes to Linux behavior**: None

This commit ports the basic account management feature of the Guest
Agent to FreeBSD. This includes:

- Automatic account and group creation
- Initial SSH public key provisioning
- Adding user to sudoers file

However, this does not include restarting sshd. This is because it's
currently only best-effort on Linux and FreeBSD does not use systemd. I
plan on adding logic to restart sshd properly on FreeBSD later.

With this change, it is now possible to SSH into a FreeBSD VM with a
static SSH key provided on boot.

NB. This PR is stacked on the previous parts. This PR will clean up the diff after the previous PRs have been merged.