### PR TITLE
fix dependency between sshd and google-guest-agent-manager.service

### DIFF
--- a/google-guest-agent-manager.service
+++ b/google-guest-agent-manager.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=Google Compute Engine Guest Agent Plugin Manager
-# Ensure we start before any SSH service or keygen process begins
-Before=sshd.service ssh.service sshd-keygen.target
-# Wait for network and group under syslog
+# Start before sshd in order to regenerate SSH host keys.
+Before=sshd.service ssh.service
 After=network-online.target syslog.service
-Wants=network-online.target
+After=network.service networking.service NetworkManager.service systemd-networkd.service
 
 [Service]
 Type=notify
@@ -14,4 +13,6 @@ Restart=always
 KillMode=process
 
 [Install]
+WantedBy=sshd.service
 WantedBy=multi-user.target
+WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service

--- a/google-guest-agent-manager.service
+++ b/google-guest-agent-manager.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Google Compute Engine Guest Agent Plugin Manager
-# Start before sshd in order to regenerate SSH host keys.
-Before=sshd.service
+# Force a hard structural requirement; sshd cannot boot without this service
+Requires=sshd-keygen.target
+Before=sshd.service sshd-keygen.target
+# Group all networking under the official, unified systemd online target
 After=network-online.target syslog.service
-After=network.service networking.service NetworkManager.service systemd-networkd.service
+Wants=network-online.target
 
 [Service]
 Type=notify
@@ -13,6 +15,4 @@ Restart=always
 KillMode=process
 
 [Install]
-WantedBy=sshd.service
 WantedBy=multi-user.target
-WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service

--- a/google-guest-agent-manager.service
+++ b/google-guest-agent-manager.service
@@ -13,6 +13,6 @@ Restart=always
 KillMode=process
 
 [Install]
-WantedBy=sshd.service
+WantedBy=sshd.service ssh.service
 WantedBy=multi-user.target
 WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service

--- a/google-guest-agent-manager.service
+++ b/google-guest-agent-manager.service
@@ -15,3 +15,4 @@ KillMode=process
 [Install]
 WantedBy=sshd.service
 WantedBy=multi-user.target
+WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service

--- a/google-guest-agent-manager.service
+++ b/google-guest-agent-manager.service
@@ -1,9 +1,8 @@
 [Unit]
 Description=Google Compute Engine Guest Agent Plugin Manager
-# Force a hard structural requirement; sshd cannot boot without this service
-Requires=sshd-keygen.target
-Before=sshd.service sshd-keygen.target
-# Group all networking under the official, unified systemd online target
+# Ensure we start before any SSH service or keygen process begins
+Before=sshd.service ssh.service sshd-keygen.target
+# Wait for network and group under syslog
 After=network-online.target syslog.service
 Wants=network-online.target
 

--- a/google-guest-agent-manager.service
+++ b/google-guest-agent-manager.service
@@ -15,4 +15,3 @@ KillMode=process
 [Install]
 WantedBy=sshd.service
 WantedBy=multi-user.target
-WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service

--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Google Compute Engine Guest Agent
 # Start before sshd in order to regenerate SSH host keys.
-Before=sshd.service
+Before=sshd.service ssh.service
 # Start after network is online and restart when network service is restarted.
 #   Debian/Ubuntu 16.04: networking.service
 #   SLES/EL7: network.service (SLES via wicked.service)

--- a/google-guest-agent.service
+++ b/google-guest-agent.service
@@ -19,6 +19,6 @@ OOMScoreAdjust=-999
 Restart=always
 
 [Install]
-WantedBy=sshd.service
+WantedBy=sshd.service ssh.service
 WantedBy=multi-user.target
 WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service


### PR DESCRIPTION
Attempts to fix a race condition between sshd and the guest agent service where on rare occasions the agent is started after the sshd service and leads to failure in test [TestSSHServiceStartsAfterGuestAgent](https://github.com/GoogleCloudPlatform/cloud-image-tests/blob/64826317fd1e94c4c08a1f8e75435e8bd6692991/test_suites/ssh/ssh_service_test.go#L34)