### PR TITLE
Replace abandoned serial dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/tink/go v1.7.0
 	github.com/kardianos/service v1.2.4
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
+	go.bug.st/serial v1.8.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sys v0.46.0
 	google.golang.org/api v0.286.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
-github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+go.bug.st/serial v1.8.0 h1:ZtnmN8aYXtPlTghwSvDWPHKBHL9TM6oFDa+KpSn4SQE=
+go.bug.st/serial v1.8.0/go.mod h1:d0MmS16Qt9b1m06yoYRNUXhRRTJV5Qg2S5EKqQtnayQ=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/utils/serial_port_logger.go
+++ b/utils/serial_port_logger.go
@@ -16,7 +16,7 @@
 
 package utils
 
-import "github.com/tarm/serial"
+import "go.bug.st/serial"
 
 // SerialPort is a type for writing to a named serial port.
 type SerialPort struct {
@@ -24,8 +24,7 @@ type SerialPort struct {
 }
 
 func (s *SerialPort) Write(b []byte) (int, error) {
-	c := &serial.Config{Name: s.Port, Baud: 115200}
-	p, err := serial.OpenPort(c)
+	p, err := serial.Open(s.Port, &serial.Mode{BaudRate: 115200})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This commit replaces the github.com/tarm/serial dependency which has not been updated in years with go.bug.st/serial. This also has the benefit of allowing Linux-to-FreeBSD builds. This change mirrors the similar change in [`github.com/GoogleCloudPlatform/google-guest-agent`](https://github.com/GoogleCloudPlatform/google-guest-agent/blob/3d7973d0a3052178c5cfe799e59abe35bb4e1192/internal/utils/serialport/serialport.go#L20).