### PR TITLE
Update transitive deps to support FreeBSD build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,14 @@ go 1.26
 
 replace github.com/GoogleCloudPlatform/guest-agent/metadata => ../metadata
 
+// These transitive dependencies brought in by github.com/google/go-tpm-tools were
+// patched to support FreeBSD builds. We can remove this replace block if they cut
+// new releases.
+replace (
+	github.com/google/go-sev-guest => github.com/google/go-sev-guest v0.15.1-0.20260714230530-c930ed67bebf
+	github.com/google/go-tdx-guest => github.com/google/go-tdx-guest v0.3.2-0.20260720181514-d0438ad17937
+)
+
 require (
 	cloud.google.com/go/storage v1.63.0
 	github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20260611222439-02d6ddff2dfb

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,10 @@ github.com/google/go-configfs-tsm v0.3.3 h1:8mrlZLYrFFxyc8PFpT1piBUFDEYBVsBjAkFC
 github.com/google/go-configfs-tsm v0.3.3/go.mod h1:in2lmJDGaYEiPOJY4vlq4lGXjkR/GcxN1k7o5oR2qn0=
 github.com/google/go-eventlog v0.0.3-0.20260617163629-883cc5652c69 h1:vW9PSMcZvz7XqNdndKzk5TmsZcD/i5Z1EmxUHMMAmqk=
 github.com/google/go-eventlog v0.0.3-0.20260617163629-883cc5652c69/go.mod h1:7huE5P8w2NTObSwSJjboHmB7ioBNblkijdzoVa2skfQ=
-github.com/google/go-sev-guest v0.15.0 h1:Xzfut5mbhcVb7TyPiyc5PolLUzdai7VH3QpyvXwcW9Y=
-github.com/google/go-sev-guest v0.15.0/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
-github.com/google/go-tdx-guest v0.3.2-0.20250814004405-ffb0869e6f4d h1:Ff8goEP/ue2/rZT5qyoRicuySCYDbAXEZS8Cf1fgsUo=
-github.com/google/go-tdx-guest v0.3.2-0.20250814004405-ffb0869e6f4d/go.mod h1:uHy3VaNXNXhl0fiPxKqTxieeouqQmW6A0EfLcaeCYBk=
+github.com/google/go-sev-guest v0.15.1-0.20260714230530-c930ed67bebf h1:R9r8Y4qRcXmTqigNKcNezYca1eFvvwC3Um/xhKq0oCc=
+github.com/google/go-sev-guest v0.15.1-0.20260714230530-c930ed67bebf/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/google/go-tdx-guest v0.3.2-0.20260720181514-d0438ad17937 h1:xkOQsuJixgma4GzK/q7fUXgL40Wh1jYhFk3VF42M4Pc=
+github.com/google/go-tdx-guest v0.3.2-0.20260720181514-d0438ad17937/go.mod h1:uHy3VaNXNXhl0fiPxKqTxieeouqQmW6A0EfLcaeCYBk=
 github.com/google/go-tpm v0.9.8 h1:slArAR9Ft+1ybZu0lBwpSmpwhRXaa85hWtMinMyRAWo=
 github.com/google/go-tpm v0.9.8/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
 github.com/google/go-tpm-tools v0.4.9 h1:jZEhnE4WRFbomSssBH2gWaIViIHU1gjH1jz76+xC9bI=


### PR DESCRIPTION
This commit pins github.com/google/go-sev-guest and github.com/google/go-tdx-guest to their latest commits because they have been patched to support FreeBSD builds.
We can remove the replace block when they both have cut releases and github.com/google/go-tpm-tools has also cut a new release that include their latest changes.